### PR TITLE
Single-use URL bug fix

### DIFF
--- a/src/Classes/Resolver.php
+++ b/src/Classes/Resolver.php
@@ -30,7 +30,7 @@ class Resolver
      */
     public function __construct(Agent $agent = null, Validation $validation = null)
     {
-        if (!$validation) {
+        if (! $validation) {
             $validation = new Validation();
         }
 


### PR DESCRIPTION
This fixes a bug that allowed multiple visits to a single-use URL if the tracking was disabled.

Issue: #22 