### PR TITLE
Updated tags

### DIFF
--- a/src/Providers/ShortURLProvider.php
+++ b/src/Providers/ShortURLProvider.php
@@ -34,12 +34,12 @@ class ShortURLProvider extends ServiceProvider
         // Config
         $this->publishes([
             __DIR__.'/../../config/short-url.php' => config_path('short-url.php'),
-        ], 'config');
+        ], 'short-url-config');
 
         // Migrations
         $this->publishes([
             __DIR__.'/../../database/migrations' => database_path('migrations'),
-        ], 'migrations');
+        ], 'short-url-migrations');
         $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
 
         // Routes


### PR DESCRIPTION
Currently if you run `php artisan vendor:publish` the package configs are marked as a generic `config`. 

![Screenshot from 2020-03-04 22-25-18](https://user-images.githubusercontent.com/12772919/75961142-18c21a00-5eca-11ea-8077-9c27e44643b8.png)

God knows how many packages are tagged like this but after this PR the publish command is specific onto which package you are publishing

![Screenshot from 2020-03-05 10-12-30](https://user-images.githubusercontent.com/12772919/75961237-4d35d600-5eca-11ea-840b-8aba407cd7aa.png)

