### PR TITLE
Adds activated_at and deactivated_at dates.

### DIFF
--- a/database/migrations/2020_04_10_224546_update_short_url_table_for_version_three_zero_zero.php
+++ b/database/migrations/2020_04_10_224546_update_short_url_table_for_version_three_zero_zero.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateShortURLTableForVersionThreeZeroZero extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('short_urls', function (Blueprint $table) {
+            $table->timestamp('activated_at')->after('track_device_type')->nullable()->default(now());
+            $table->timestamp('deactivated_at')->after('activated_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('short_urls', function (Blueprint $table) {
+            $table->dropColumn(['activated_at', 'deactivated_at']);
+        });
+    }
+}

--- a/database/migrations/2020_04_10_224546_update_short_url_table_for_version_three_zero_zero.php
+++ b/database/migrations/2020_04_10_224546_update_short_url_table_for_version_three_zero_zero.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class UpdateShortURLTableForVersionThreeZeroZero extends Migration

--- a/src/Facades/ShortURL.php
+++ b/src/Facades/ShortURL.php
@@ -3,6 +3,7 @@
 namespace AshAllenDesign\ShortURL\Facades;
 
 use AshAllenDesign\ShortURL\Classes\Builder;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Facade;
 use RuntimeException;
 
@@ -21,6 +22,8 @@ use RuntimeException;
  * @method static self urlKey(string $key)
  * @method static self redirectStatusCode(int $statusCode)
  * @method static self resetOptions()
+ * @method static self activateAt(Carbon $activationTime)
+ * @method static self deactivateAt(Carbon $deactivationTime)
  * @method static \AshAllenDesign\ShortURL\Models\ShortURL make()
  *
  * @see Builder

--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -24,6 +24,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property bool track_browser_version
  * @property bool track_referer_url
  * @property bool track_device_type
+ * @property Carbon activated_at
+ * @property Carbon deactivated_at
  * @property Carbon created_at
  * @property Carbon updated_at
  */
@@ -55,6 +57,8 @@ class ShortURL extends Model
         'track_browser_version',
         'track_referer_url',
         'track_device_type',
+        'activated_at',
+        'deactivated_at',
     ];
 
     /**
@@ -63,6 +67,8 @@ class ShortURL extends Model
      * @var array
      */
     protected $dates = [
+        'activated_at',
+        'deactivated_at',
         'created_at',
         'updated_at',
     ];

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -81,8 +81,7 @@ class BuilderTest extends TestCase
     }
 
     /** @test */
-    public function destination_url_is_changed_to_https_if_enforce_https_flag_is_set_to_false_in_the_config_but_set_when_creating_url(
-    )
+    public function destination_url_is_changed_to_https_if_enforce_https_flag_is_set_to_false_in_the_config_but_set_when_creating_url()
     {
         Config::set('short-url.enforce_https', false);
         $builder = new Builder();
@@ -291,7 +290,7 @@ class BuilderTest extends TestCase
             'track_referer_url'              => false,
             'track_device_type'              => true,
             'activated_at'                   => now(),
-            'deactivated_at'                 => null
+            'deactivated_at'                 => null,
         ]);
     }
 


### PR DESCRIPTION
This adds the functionality to activate and deactivate short URLs. This could be useful for marketing campaigns where the marketer only wants the URL live within a certain timeframe.