### PR TITLE
Optional config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
         - [Tracking Visits](#tracking-visits)
             - [Default Tracking](#default-tracking)
             - [Tracking Fields](#tracking-fields)
+        - [Config Validation](#config-validation)
     - [Helper Methods](#helper-methods)
         - [Visits](#visits)
         - [Find by URL Key](#find-by-url-key)
@@ -425,6 +426,15 @@ For example, the snippet below shows how we could record all of the fields apart
         ],
     ],
 ```
+
+#### Config Validation
+By default, the values defined in the ``` short-url.php ``` config file are not validated. However, the library contains
+a validator that can be used to ensure that your values are safe to use. To enable the config validation, you can set the
+following option in the config:
+
+```
+'validate_config' => true,
+``` 
 
 ### Helper Methods
 #### Visits

--- a/config/short-url.php
+++ b/config/short-url.php
@@ -86,4 +86,16 @@ return [
             'device_type'              => true,
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Config Validation
+    |--------------------------------------------------------------------------
+    |
+    | Choose whether if you want the config to be validated. This
+    | can be useful for ensuring that your config values are
+    | safe to use.
+    |
+    */
+    'validate_config' => false,
 ];

--- a/src/Providers/ShortURLProvider.php
+++ b/src/Providers/ShortURLProvider.php
@@ -45,6 +45,8 @@ class ShortURLProvider extends ServiceProvider
         // Routes
         $this->loadRoutesFrom(__DIR__.'/../../routes/web.php');
 
-        (new Validation())->validateConfig();
+        if (config('short-url') && config('short-url.validate_config')) {
+            (new Validation())->validateConfig();
+        }
     }
 }


### PR DESCRIPTION
This PR makes the config validation optional. Previously the config was always validated but this could cause some issues if the config had been cached before installing.

There's now a new config value called ``` validate_config ``` that can be used to toggle the validation.

Addresses: https://github.com/ash-jc-allen/short-url/issues/49