### PR TITLE
Remove Laravel 5.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,34 +7,18 @@ cache:
 matrix:
   fast_finish: true
   include:
-#     Laravel 5.8.*
-#       --> PHP 7.2
-    - php: 7.2
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.2
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
-#       --> PHP 7.3
-    - php: 7.3
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.3
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
-#       --> PHP 7.4
-    - php: 7.4
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.4
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
-#     Laravel 6.*
-#       --> PHP 7.2
+    #     Laravel 6.*
+    #       --> PHP 7.2
     - php: 7.2
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.2
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
-#       --> PHP 7.3
+    #       --> PHP 7.3
     - php: 7.3
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.3
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
-#       --> PHP 7.4
+    #       --> PHP 7.4
     - php: 7.4
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.4

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A Laravel package that can be used for adding shortened URLs to your existing we
 The package has been developed and tested to work with the following minimum requirements:
 
 - PHP 7.2
-- Laravel 5.8
+- Laravel 6.0
 
 Short URL requires either the [BC Math](https://secure.php.net/manual/en/book.bc.php) or [GMP](https://secure.php.net/manual/en/book.gmp.php) PHP extensions in order to work.
 

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
   "require": {
     "php": "^7.2",
     "nesbot/carbon": "~2.0",
-    "illuminate/container": "^5.8|^6.0|^7.0",
-    "illuminate/database": "^5.8|^6.0|^7.0",
+    "illuminate/container": "^6.0|^7.0",
+    "illuminate/database": "^6.0|^7.0",
     "jenssegers/agent": "^2.6",
     "hashids/hashids": "^4.0"
   },


### PR DESCRIPTION
This PR removes support for Laravel 5.8 and makes the Laravel 6 the minimum required version.