### PR TITLE
Allow to set the URL suffix

### DIFF
--- a/config/short-url.php
+++ b/config/short-url.php
@@ -18,6 +18,13 @@ return [
     'disable_default_route' => false,
 
     /*
+    | Define the string that will be appended to the app URL. For instance, when set to 'short', this
+    | means that the shortened URL can be accessed via <app_url>/short/<hash>.
+    |
+    */
+    'url_suffix' => 'short',
+
+    /*
     |--------------------------------------------------------------------------
     | Enforce HTTPS in the destination URL
     |--------------------------------------------------------------------------

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -431,7 +431,7 @@ class Builder
     {
         return ShortURL::create([
             'destination_url'                => $this->destinationUrl,
-            'default_short_url'              => config('app.url').'/short/'.$this->urlKey,
+            'default_short_url'              => config('app.url') . '/' . config('short-url.url_suffix') . '/' . $this->urlKey,
             'url_key'                        => $this->urlKey,
             'single_use'                     => $this->singleUse,
             'track_visits'                   => $this->trackVisits,

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -431,7 +431,7 @@ class Builder
     {
         return ShortURL::create([
             'destination_url'                => $this->destinationUrl,
-            'default_short_url'              => config('app.url') . '/' . config('short-url.url_suffix') . '/' . $this->urlKey,
+            'default_short_url'              => config('app.url').'/'.config('short-url.url_suffix').'/'.$this->urlKey,
             'url_key'                        => $this->urlKey,
             'single_use'                     => $this->singleUse,
             'track_visits'                   => $this->trackVisits,


### PR DESCRIPTION
This PR address the issue discussed in #74.

A new config key was added, `url_suffix`, that is used when building the shortened URL.