### PR TITLE
add purge command, key generation attempts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "nesbot/carbon": "~2.0",
     "illuminate/container": "^8.0",
     "illuminate/database": "^8.0",
+  	"illuminate/console": "^8.0",
     "jenssegers/agent": "^2.6",
     "hashids/hashids": "^4.0"
   },

--- a/config/short-url.php
+++ b/config/short-url.php
@@ -76,6 +76,17 @@ return [
     */
     'key_length'            => 5,
 
+	/*
+    |--------------------------------------------------------------------------
+    | Key generation attemps
+    |--------------------------------------------------------------------------
+    |
+    | In case of existing key, set the number of attemps to generate a
+	| new one before throw exception
+    |
+    */
+	'key_generate_attemps' => 3,
+
     /*
     |--------------------------------------------------------------------------
     | Key Salt

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AshAllenDesign\ShortURL\Commands;
+
+use Illuminate\Console\Command;
+
+/**
+ * Class BaseCommand
+ * @package AshAllenDesign\ShortURL\Commands
+ */
+abstract class BaseCommand extends Command
+{
+
+}

--- a/src/Commands/Purge.php
+++ b/src/Commands/Purge.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace AshAllenDesign\ShortURL\Commands;
+
+use AshAllenDesign\ShortURL\Models\ShortURL;
+
+/**
+ * Class Purge
+ * @package AshAllenDesign\ShortURL\Commands
+ */
+class Purge extends BaseCommand
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'short-url:purge';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Purge deactivated links';
+
+	/**
+	 *
+	 */
+	public function handle()
+	{
+		ShortURL::query()
+			->where('deactivated_at', '<', now()->toDateTimeString())
+			->orWhere(function ($query) {
+				$query->where('single_use', 1)
+					->whereHas('visits');
+			})
+			->delete();
+	}
+}

--- a/src/Providers/ShortURLProvider.php
+++ b/src/Providers/ShortURLProvider.php
@@ -4,6 +4,7 @@ namespace AshAllenDesign\ShortURL\Providers;
 
 use AshAllenDesign\ShortURL\Classes\Builder;
 use AshAllenDesign\ShortURL\Classes\Validation;
+use AshAllenDesign\ShortURL\Commands\Purge;
 use AshAllenDesign\ShortURL\Exceptions\ValidationException;
 use Illuminate\Support\ServiceProvider;
 
@@ -48,5 +49,11 @@ class ShortURLProvider extends ServiceProvider
         if (config('short-url') && config('short-url.validate_config')) {
             (new Validation())->validateConfig();
         }
+
+	    if ($this->app->runningInConsole()) {
+		    $this->commands([
+			    Purge::class
+		    ]);
+	    }
     }
 }


### PR DESCRIPTION
The idea is to purge the database by adding this command to the Laravel scheduler.

The second change is about key generation: if key is not unique, try to generate again within configured attempts (default 3).
If still not unique, throw exception as before.