### PR TITLE
Makes possible to use custom base URL and remove prefix.

### DIFF
--- a/config/short-url.php
+++ b/config/short-url.php
@@ -9,9 +9,33 @@ return [
     |
     | This configuration value is used to determine the prefix that
     | is registered for the short URL route.
+    | If you want to get rid of the prefix you can use either an empty string or `null`.
     |
     */
     'prefix' => '/short',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Base URL
+    |--------------------------------------------------------------------------
+    |
+    | This configuration value is used to determine the base url that you want
+    | to use for the generated short URL base path.
+    |
+    | Example:
+    | Let's say your app has its base URL config('app.url') set to https://full-path-to-my-app.com.
+    | Then let's say you have a different domain that you want to use for your short-urls,
+    | something like https://short.is.
+    | That way, when you generate a short URL that points to `https://destination.com`,
+    | instead of having a short version like `https://full-path-to-my-app.com/<prefix>/k4x9e`,
+    | you would get `https://short.is/<prefix>/k4x9e`.
+    | If you set your prefix setting to either an empty string or `null` you could go even further
+    | and have your shortened URL like `https://short.is/k4x9e`.
+    |
+    | Keep in mind that this will require extra steps to handle the additional domain.
+    |
+    */
+    'base_url' => config('app.url'),
 
     /*
     |--------------------------------------------------------------------------

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,4 @@ use AshAllenDesign\ShortURL\Controllers\ShortURLController;
 use AshAllenDesign\ShortURL\Facades\ShortURL;
 use Illuminate\Support\Facades\Route;
 
-if (! config('short-url.disable_default_route')) {
-    Route::get('/'.ShortURL::prefix().'/{shortURLKey}', ShortURLController::class)->name('short-url.invoke');
-}
+Route::get('/'.ShortURL::prefix().'/{shortURLKey}', ShortURLController::class)->name('short-url.invoke');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,9 @@
 <?php
 
+use AshAllenDesign\ShortURL\Controllers\ShortURLController;
 use AshAllenDesign\ShortURL\Facades\ShortURL;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/'.ShortURL::prefix().'/{shortURLKey}', 'AshAllenDesign\ShortURL\Controllers\ShortURLController')->name('short-url.invoke');
+if (! config('short-url.disable_default_route')) {
+    Route::get('/'.ShortURL::prefix().'/{shortURLKey}', ShortURLController::class)->name('short-url.invoke');
+}

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -181,6 +181,17 @@ class Builder
     }
 
     /**
+     * Returns the base URL to be used by the URL shortener generator.
+     * Defaults to config('app.url').
+     *
+     * @return string
+     */
+    public function baseUrl(): string
+    {
+        return rtrim(config('short-url.base_url'), '/');
+    }
+
+    /**
      * Set the destination URL that the shortened URL
      * will redirect to.
      *
@@ -462,9 +473,15 @@ class Builder
      */
     protected function insertShortURLIntoDatabase(): ShortURL
     {
+        $base_url = $this->baseUrl();
+
+        if (! empty($this->prefix())) {
+            $base_url .= "/{$this->prefix()}";
+        }
+
         return ShortURL::create([
             'destination_url'                => $this->destinationUrl,
-            'default_short_url'              => config('app.url').'/'.$this->prefix().'/'.$this->urlKey,
+            'default_short_url'              => "{$base_url}/{$this->urlKey}",
             'url_key'                        => $this->urlKey,
             'single_use'                     => $this->singleUse,
             'forward_query_params'           => $this->forwardQueryParams,

--- a/src/Controllers/ShortURLController.php
+++ b/src/Controllers/ShortURLController.php
@@ -27,11 +27,6 @@ class ShortURLController
         /** @var Route $requestRoute */
         $requestRoute = $request->route();
 
-        if ($requestRoute->getName() === 'short-url.invoke'
-            && config('short-url.disable_default_route')) {
-            abort(404);
-        }
-
         $shortURL = ShortURL::where('url_key', $shortURLKey)->firstOrFail();
 
         $resolver->handleVisit(request(), $shortURL);

--- a/src/Controllers/ShortURLController.php
+++ b/src/Controllers/ShortURLController.php
@@ -27,6 +27,11 @@ class ShortURLController
         /** @var Route $requestRoute */
         $requestRoute = $request->route();
 
+        if ($requestRoute->getName() === 'short-url.invoke'
+            && config('short-url.disable_default_route')) {
+            abort(404);
+        }
+
         $shortURL = ShortURL::where('url_key', $shortURLKey)->firstOrFail();
 
         $resolver->handleVisit(request(), $shortURL);

--- a/src/Providers/ShortURLProvider.php
+++ b/src/Providers/ShortURLProvider.php
@@ -5,6 +5,7 @@ namespace AshAllenDesign\ShortURL\Providers;
 use AshAllenDesign\ShortURL\Classes\Builder;
 use AshAllenDesign\ShortURL\Classes\Validation;
 use AshAllenDesign\ShortURL\Exceptions\ValidationException;
+use AshAllenDesign\ShortURL\ShortUrl;
 use Illuminate\Support\ServiceProvider;
 
 class ShortURLProvider extends ServiceProvider
@@ -43,10 +44,17 @@ class ShortURLProvider extends ServiceProvider
         ], 'short-url-migrations');
 
         // Routes
-        $this->loadRoutesFrom(__DIR__.'/../../routes/web.php');
+        $this->registerRoutes();
 
         if (config('short-url') && config('short-url.validate_config')) {
             (new Validation())->validateConfig();
+        }
+    }
+
+    protected function registerRoutes(): void
+    {
+        if (ShortUrl::$registers_routes) {
+            $this->loadRoutesFrom(__DIR__.'/../../routes/web.php');
         }
     }
 }

--- a/src/ShortUrl.php
+++ b/src/ShortUrl.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace AshAllenDesign\ShortURL;
+
+class ShortUrl
+{
+    /**
+     * Indicates if the default route will be registered.
+     *
+     * @var bool
+     */
+    public static bool $registers_routes = true;
+
+    /**
+     * Configure to not register its routes.
+     *
+     * @return static
+     */
+    public static function ignoreRoutes(): static
+    {
+        static::$registers_routes = false;
+
+        return new static;
+    }
+}

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -292,6 +292,44 @@ class BuilderTest extends TestCase
     }
 
     /** @test */
+    public function default_short_url_uses_custom_base_url(): void
+    {
+        Config::set('short-url.base_url', 'https://short.is');
+
+        $builder = new Builder();
+        $shortURL = $builder->destinationUrl('https://domain.com')
+            ->urlKey('customKey')
+            ->secure()
+            ->trackVisits(false)
+            ->trackDeviceType(true)
+            ->trackRefererURL(false)
+            ->trackBrowser(true)
+            ->trackOperatingSystemVersion(false)
+            ->make();
+
+        $this->assertTrue(str_starts_with($shortURL->default_short_url, 'https://short.is'));
+    }
+
+    /** @test */
+    public function default_short_url_uses_default_base_url(): void
+    {
+        $default_base_url = Config::get('app.url');
+
+        $builder = new Builder();
+        $shortURL = $builder->destinationUrl('https://domain.com')
+            ->urlKey('customKey')
+            ->secure()
+            ->trackVisits(false)
+            ->trackDeviceType(true)
+            ->trackRefererURL(false)
+            ->trackBrowser(true)
+            ->trackOperatingSystemVersion(false)
+            ->make();
+
+        $this->assertTrue(str_starts_with($shortURL->default_short_url, $default_base_url));
+    }
+
+    /** @test */
     public function short_url_can_be_created_and_stored_in_the_database()
     {
         $builder = new Builder();


### PR DESCRIPTION
## This PR aims to make it possible for developers to change the base URL that's going to be used on the `default_short_url` column and also remove the `prefix` if they want to.

### Use case

An app has a base URL `config('app.url')` set to `https://a-long-domain-for-the-app.com`.  
The app developers want to use the URL shortener to create tiny URLs so their users can have a better experience.
To do that, the developers would like to use their tiny domain instead, `https://tiny-domain.is`.  
They also want to be able to remove the `prefix` all along.  

With the above, the `default_short_url` would look like:
- `destination_url`: `https://a-long-domain-for-the-app.com/some-inner-route-for-my-users`
- `default_short_url`: `https://tiny-domain.is/k4x9e`

Resolves #113 

Thanks in advance, for your time @ash-jc-allen, when reviewing this PR.