### PR TITLE
Allow overriding key generator in builder

### DIFF
--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -368,6 +368,19 @@ class Builder
     }
 
     /**
+     * Explicitly set the key generator
+     *
+     * @param  KeyGenerator $keyGenerator
+     * @return $this
+     */
+    public function keyGenerator(KeyGenerator $keyGenerator): self
+    {
+        $this->keyGenerator = $keyGenerator;
+
+        return $this;
+    }
+
+    /**
      * Override the HTTP status code that will be used
      * for redirecting the visitor.
      *

--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -18,9 +18,9 @@ class KeyGenerator
     /**
      * KeyGenerator constructor.
      */
-    public function __construct()
+    public function __construct(Hashids $hashids = null)
     {
-        $this->hashids = new Hashids(config('short-url.key_salt'), config('short-url.key_length'), config('short-url.alphabet'));
+        $this->hashids = $hashids ?: new Hashids(config('short-url.key_salt'), config('short-url.key_length'), config('short-url.alphabet'));
     }
 
     /**


### PR DESCRIPTION
In some situations I need to be able to change the hashids instance on-the-fly. Primarily in order to change the key_length at runtime. This is currently not possible. The property is private and is not injectable in the KeyGenerator class. This PR allows the user to inject a hashids instance to the KeyGenerator instance. It also adds a method to the Builder class so it is possible the change the keyGenerator after instantiation. It means you can now do the following:

```
ShortUrl::destinationUrl('https://google.com')
    ->keyGenerator(new KeyGenerator(new Hashids))
    ->make();
```

```
$builder = new Builder(null, new KeyGenerator(new Hashids));

$builder->destinationUrl('https://google.com')->make();
```