### PR TITLE
Added ability to remove the prefix from default short URLs

### DIFF
--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -173,11 +173,17 @@ class Builder
     /**
      * Get the short URL route prefix.
      *
-     * @return string
+     * @return string|null
      */
-    public function prefix(): string
+    public function prefix(): ?string
     {
-        return trim(config('short-url.prefix'), '/');
+        $prefix = config('short-url.prefix');
+
+        if ($prefix === null) {
+            return null;
+        }
+
+        return trim($prefix, '/');
     }
 
     /**
@@ -487,7 +493,7 @@ class Builder
     {
         return ShortURL::create([
             'destination_url'                => $this->destinationUrl,
-            'default_short_url'              => config('app.url').'/'.$this->prefix().'/'.$this->urlKey,
+            'default_short_url'              => $this->buildDefaultShortUrl(),
             'url_key'                        => $this->urlKey,
             'single_use'                     => $this->singleUse,
             'forward_query_params'           => $this->forwardQueryParams,
@@ -613,5 +619,22 @@ class Builder
         $this->trackDeviceType = null;
 
         return $this;
+    }
+
+    /**
+     * Build and return the default short URL that will be stored in the
+     * database.
+     *
+     * @return string
+     */
+    private function buildDefaultShortUrl(): string
+    {
+        $baseUrl = config('app.url').'/';
+
+        if ($this->prefix() !== null) {
+            $baseUrl .= $this->prefix().'/';
+        }
+
+        return $baseUrl.$this->urlKey;
     }
 }

--- a/src/Facades/ShortURL.php
+++ b/src/Facades/ShortURL.php
@@ -27,8 +27,8 @@ use RuntimeException;
  * @method static self activateAt(Carbon $activationTime)
  * @method static self deactivateAt(Carbon $deactivationTime)
  * @method static \AshAllenDesign\ShortURL\Models\ShortURL make()
- * @method static string prefix()
- * @method static string middleware()
+ * @method static string|null prefix()
+ * @method static array middleware()
  *
  * @see Builder
  */

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -490,15 +490,34 @@ class BuilderTest extends TestCase
 
     /**
      * @test
-     * @testWith ["s"]
-     *           ["/s"]
-     *           ["/s/"]
-     *           ["s/"]
+     * @testWith ["s", "s"]
+     *           ["/s", "s"]
+     *           ["/s/", "s"]
+     *           ["s/", "s"]
+     *           [null, null]
      */
-    public function correct_prefix_is_returned($prefix)
+    public function correct_prefix_is_returned(?string $prefix, ?string $expected)
     {
         Config::set('short-url.prefix', $prefix);
 
-        self::assertSame('s', ShortURLAlias::prefix());
+        self::assertSame($expected, ShortURLAlias::prefix());
+    }
+
+    /** @test */
+    public function short_url_can_be_created_with_a_null_prefix(): void
+    {
+        $deactivateTime = now()->addHours(2);
+
+        Config::set('short-url.prefix', null);
+
+        ShortURLAlias::destinationUrl('http://domain.com')
+            ->urlKey('customKey')
+            ->deactivateAt($deactivateTime)
+            ->make();
+
+        $this->assertDatabaseHas('short_urls', [
+            'default_short_url' => config('app.url').'/customKey',
+            'url_key' => 'customKey',
+        ]);
     }
 }

--- a/tests/Unit/Controllers/ShortURLControllerEmptyPrefixTest.php
+++ b/tests/Unit/Controllers/ShortURLControllerEmptyPrefixTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AshAllenDesign\ShortURL\Tests\Unit\Controllers;
+
+use AshAllenDesign\ShortURL\Models\ShortURL;
+use AshAllenDesign\ShortURL\Tests\Unit\TestCase;
+
+class ShortURLControllerEmptyPrefixTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('short-url.prefix', null);
+
+        parent::getEnvironmentSetUp($app);
+    }
+
+    /** @test */
+    public function visitor_is_redirected_to_the_destination_url_with_null_prefix()
+    {
+        ShortURL::create([
+            'destination_url'      => 'https://google.com',
+            'default_short_url'    => config('app.url').'/12345',
+            'url_key'              => '12345',
+            'single_use'           => true,
+            'track_visits'         => true,
+            'redirect_status_code' => 301,
+            'activated_at'         => now()->subMinute(),
+        ]);
+
+        $this->get('/12345')->assertStatus(301)->assertRedirect('https://google.com');
+    }
+}


### PR DESCRIPTION
This PR adds the ability to create short URLs with an empty prefix.

If the `short-url.prefix` config field is set to `null`, a prefix won't be used in the default short URL when it's stored in the database.

I've not made any changes to the default route in `web.php` because it appears that Laravel strips double forward slashes, so we don't need to handle this ourselves (as far as I can tell).