### PR TITLE
feat: Add Builder::toArray() method

### DIFF
--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -473,11 +473,11 @@ class Builder
             throw new ShortURLException('No destination URL has been set.');
         }
 
-        $this->setOptions();
+        $data = $this->toArray();
 
         $this->checkKeyDoesNotExist();
 
-        $shortURL = $this->insertShortURLIntoDatabase();
+        $shortURL = ShortURL::create($data);
 
         $this->resetOptions();
 
@@ -485,13 +485,15 @@ class Builder
     }
 
     /**
-     * Store the short URL in the database.
+     * Returns an array of all properties used during record creation.
      *
-     * @return ShortURL
+     * @return array<string,mixed>
      */
-    protected function insertShortURLIntoDatabase(): ShortURL
+    public function toArray(): array
     {
-        return ShortURL::create([
+        $this->setOptions();
+
+        return [
             'destination_url'                => $this->destinationUrl,
             'default_short_url'              => $this->buildDefaultShortUrl(),
             'url_key'                        => $this->urlKey,
@@ -508,7 +510,7 @@ class Builder
             'track_device_type'              => $this->trackDeviceType,
             'activated_at'                   => $this->activateAt,
             'deactivated_at'                 => $this->deactivateAt,
-        ]);
+        ];
     }
 
     /**


### PR DESCRIPTION
This PR adds a `toArray()` method into the Builder class. Currently, all Builder properties are protected and so are the methods responsible for populating default values for many of them. Adding the `toArray()` methods adds a convenient way of exposing that data without having to change any Builder class property or method visibility.

My specific use case for this was the need to create new ShortURL records without using Builder. When using Laravel Nova, the model `create()` method is invoked however many of the ShortURL model fields are set using logic in the Builder class not in the model itself. I wrote a model observer that listens for the ShortURL::creating event to be raised by Nova. I wanted to use the logic in Builder to allow me to populate missing fields during creation. Adding a `toArray` method gives me access to these fields without too needed to copy code from Builder into my observer.

I am hoping you're able to accept this PR. If not, I would love to get feedback and some ideas on how I can solve my problem above.

