### PR TITLE
Added support for "when"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
         - [Redirect Status Code](#redirect-status-code)
         - [Activation and Deactivation Times](#activation-and-deactivation-times)
         - [Facade](#facade)
+        - [Conditionals](#conditionals)
     - [Using the Shortened URLs](#using-the-shortened-urls)
         - [Default Route and Controller](#default-route-and-controller)
         - [Custom Route](#custom-route)
@@ -336,6 +337,42 @@ class Controller
     }
 }
 ```
+
+#### Conditionals
+
+The `Builder` class uses the `Illuminate\Support\Traits\Conditionable` trait, so you can use the `when` and `unless` methods when building your short URLs.
+
+For example, let's take this block of code that uses `if` when building the short URL:
+
+```php
+use AshAllenDesign\ShortURL\Classes\Builder;
+ 
+$shortURLObject = (new Builder())
+    ->destinationUrl('https://destination.com');
+
+if ($request->date('activation')) {
+    $builder = $builder->activateAt($request->date('activation'));
+};
+
+$shortURLObject = $builder->make();)
+```
+
+This could be rewritten using `when` like so:
+
+ ```php
+use AshAllenDesign\ShortURL\Classes\Builder;
+use Carbon\Carbon;
+ 
+$shortURLObject = (new Builder())
+    ->destinationUrl('https://destination.com')
+    ->when(
+        $request->date('activation'),
+        function (Builder $builder, Carbon $activateDate): Builder  {
+            return $builder->activateAt($activateDate);
+        },
+    )
+    ->make();
+ ```
 
 ### Using the Shortened URLs
 #### Default Route and Controller

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -7,9 +7,12 @@ use AshAllenDesign\ShortURL\Exceptions\ValidationException;
 use AshAllenDesign\ShortURL\Models\ShortURL;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 
 class Builder
 {
+    use Conditionable;
+
     /**
      * The class that is used for generating the
      * random URL keys.

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -520,4 +520,22 @@ class BuilderTest extends TestCase
             'url_key' => 'customKey',
         ]);
     }
+
+    /**
+     * @test
+     * @testWith [true, "https://domain.com"]
+     *           [false, "https://fallback.com"]
+     */
+    public function data_can_be_set_on_the_builder_using_when(bool $flag, string $destination): void
+    {
+        $shortUrl = (new Builder())
+            ->when(
+                $flag,
+                fn (Builder $builder): Builder => $builder->destinationUrl('https://domain.com'),
+                fn (Builder $builder): Builder => $builder->destinationUrl('https://fallback.com')
+            )
+            ->make();
+
+        $this->assertSame($destination, $shortUrl->destination_url);
+    }
 }


### PR DESCRIPTION
This PR adds support for using `when` to chain methods in the `Builder` like so:

```php
$shortUrl = (new Builder())
       ->when(
                $flag,
                fn (Builder $builder): Builder => $builder->destinationUrl('https://domain.com'),
                fn (Builder $builder): Builder => $builder->destinationUrl('https://fallback.com')
        )
         ->make();
```