### PR TITLE
Fix `null` prefix bug

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,5 @@
 <?php
 
 use AshAllenDesign\ShortURL\Facades\ShortURL;
-use Illuminate\Support\Facades\Route;
 
-Route::middleware(ShortURL::middleware())->group(function () {
-    Route::get('/'.ShortURL::prefix().'/{shortURLKey}', 'AshAllenDesign\ShortURL\Controllers\ShortURLController')->name('short-url.invoke');
-});
+ShortURL::routes();

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -208,6 +208,10 @@ class Builder
      */
     public function routes(): void
     {
+        if (config('short-url.disable_default_route')) {
+            return;
+        }
+
         Route::middleware($this->middleware())->group(function (): void {
             Route::get(
                 '/'.$this->prefix().'/{shortURLKey}',

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -6,8 +6,10 @@ use AshAllenDesign\ShortURL\Exceptions\ShortURLException;
 use AshAllenDesign\ShortURL\Exceptions\ValidationException;
 use AshAllenDesign\ShortURL\Models\ShortURL;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
+use AshAllenDesign\ShortURL\Controllers\ShortURLController;
 
 class Builder
 {
@@ -197,6 +199,21 @@ class Builder
     public function middleware(): array
     {
         return config('short-url.middleware', []);
+    }
+
+    /**
+     * Register the routes to handle the Short URL visits.
+     *
+     * @return void
+     */
+    public function routes(): void
+    {
+        Route::middleware($this->middleware())->group(function (): void {
+            Route::get(
+                '/'.$this->prefix().'/{shortURLKey}',
+                ShortURLController::class
+            )->name('short-url.invoke');
+        });
     }
 
     /**

--- a/src/Controllers/ShortURLController.php
+++ b/src/Controllers/ShortURLController.php
@@ -6,16 +6,13 @@ use AshAllenDesign\ShortURL\Classes\Resolver;
 use AshAllenDesign\ShortURL\Models\ShortURL;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Routing\Route;
 
 class ShortURLController
 {
     /**
-     * Redirect the user to the intended destination
-     * URL. If the default route has been disabled
-     * in the config but the controller has been
-     * reached using that route, return HTTP
-     * 404.
+     * Redirect the user to the intended destination URL. If the default
+     * route has been disabled in the config but the controller has
+     * been reached using that route, return HTTP 404.
      *
      * @param  Request  $request
      * @param  Resolver  $resolver
@@ -24,14 +21,6 @@ class ShortURLController
      */
     public function __invoke(Request $request, Resolver $resolver, string $shortURLKey): RedirectResponse
     {
-        /** @var Route $requestRoute */
-        $requestRoute = $request->route();
-
-        if ($requestRoute->getName() === 'short-url.invoke'
-            && config('short-url.disable_default_route')) {
-            abort(404);
-        }
-
         $shortURL = ShortURL::where('url_key', $shortURLKey)->firstOrFail();
 
         $resolver->handleVisit(request(), $shortURL);

--- a/src/Facades/ShortURL.php
+++ b/src/Facades/ShortURL.php
@@ -29,6 +29,8 @@ use RuntimeException;
  * @method static \AshAllenDesign\ShortURL\Models\ShortURL make()
  * @method static string|null prefix()
  * @method static array middleware()
+ * @method static array toArray()
+ * @method static void routes()
  *
  * @see Builder
  */

--- a/tests/Unit/Controllers/ShortURLControllerTest.php
+++ b/tests/Unit/Controllers/ShortURLControllerTest.php
@@ -37,24 +37,6 @@ class ShortURLControllerTest extends TestCase
     }
 
     /** @test */
-    public function request_is_aborted_if_custom_routing_is_enabled_but_the_default_route_has_been_used()
-    {
-        Config::set('short-url.disable_default_route', true);
-
-        ShortURL::create([
-            'destination_url'      => 'https://google.com',
-            'default_short_url'    => config('app.url').'/short/12345',
-            'url_key'              => '12345',
-            'single_use'           => true,
-            'track_visits'         => true,
-            'redirect_status_code' => 301,
-            'activated_at'         => now()->subMinute(),
-        ]);
-
-        $this->get('/short/12345')->assertNotFound();
-    }
-
-    /** @test */
     public function event_is_dispatched_when_the_short_url_is_visited()
     {
         Event::fake();

--- a/tests/Unit/Controllers/ShortURLDisableRouteTest.php
+++ b/tests/Unit/Controllers/ShortURLDisableRouteTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AshAllenDesign\ShortURL\Tests\Unit\Controllers;
+
+use AshAllenDesign\ShortURL\Models\ShortURL;
+use AshAllenDesign\ShortURL\Tests\Unit\TestCase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+
+class ShortURLDisableRouteTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('short-url.disable_default_route', true);
+
+        parent::getEnvironmentSetUp($app);
+    }
+
+    /** @test */
+    public function request_is_aborted_if_custom_routing_is_enabled_but_the_default_route_has_been_used(): void
+    {
+        ShortURL::create([
+            'destination_url'      => 'https://google.com',
+            'default_short_url'    => config('app.url').'/short/12345',
+            'url_key'              => '12345',
+            'single_use'           => true,
+            'track_visits'         => true,
+            'redirect_status_code' => 301,
+            'activated_at'         => now()->subMinute(),
+        ]);
+
+        $this->get('/short/12345')->assertNotFound();
+    }
+}


### PR DESCRIPTION
This PR fixes a bug that was caused by the default short URL route being registered before the routes in the application's `web.php` file. The route was acting as a catch-all route and always resulting in a 404 response.

This PR adds a new `ShortURL::routes()` method that you can manually add to your application's routes. This means that you can disable the route from being automatically registered and then register it yourself at the bottom of your routes file.

We're also changing the way the default route is handled if the `disable_default_route` config value is disabled. Previously, if the field was disabled, we would handle this inside the `ShortURLController` and return a 404 response. Now, if the field is disabled, we won't register the route at all, so we don't need to handle it in the controller anymore.