### PR TITLE
Lift condition into the package's route file

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -2,4 +2,6 @@
 
 use AshAllenDesign\ShortURL\Facades\ShortURL;
 
-ShortURL::routes();
+if (!config('short-url.disable_default_route')) {
+    ShortURL::routes();
+}

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -208,10 +208,6 @@ class Builder
      */
     public function routes(): void
     {
-        if (config('short-url.disable_default_route')) {
-            return;
-        }
-
         Route::middleware($this->middleware())->group(function (): void {
             Route::get(
                 '/'.$this->prefix().'/{shortURLKey}',


### PR DESCRIPTION
I added the condition for registering the package's route in the `routes` method, but this meant that you couldn't manually register the routes yourself. I've now lifted this condition out into the package's `web.php` file so that you can now manually register the routes.