### PR TITLE
Added default_url config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 <p align="center">
 <a href="https://packagist.org/packages/ashallendesign/short-url"><img src="https://img.shields.io/packagist/v/ashallendesign/short-url.svg?style=flat-square" alt="Latest Version on Packagist"></a>
-<a href="https://github.com/ash-jc-allen/short-url"><img src="https://img.shields.io/github/workflow/status/ash-jc-allen/short-url/run-tests?style=flat-square" alt="Build Status"></a>
 <a href="https://packagist.org/packages/ashallendesign/short-url"><img src="https://img.shields.io/packagist/dt/ashallendesign/short-url.svg?style=flat-square" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/ashallendesign/short-url"><img src="https://img.shields.io/packagist/php-v/ashallendesign/short-url?style=flat-square" alt="PHP from Packagist"></a>
 <a href="https://github.com/ash-jc-allen/short-url/blob/master/LICENSE"><img src="https://img.shields.io/github/license/ash-jc-allen/short-url?style=flat-square" alt="GitHub license"></a>
@@ -415,6 +414,20 @@ do this are provided for this in the [Customisation](#customisation) section bel
 ### Customisation
 
 #### Customising the Default Route
+
+#### Customising the Default URL
+
+The package comes with a route that you can use for your short URLs. By default, this route uses your Laravel app's `app.url` config field to build the URL.
+
+However, you might want to override this and use a different URL for your short URLs. For instance, you might want to use a different domain name for your short URLs.
+
+To override the base URL, you can set the `default_url` config field. For example, to set the base URL to `https://example.com`, you can set the `default_url` in your `config/short-url.php` file like so:
+
+```php
+'default_url' => 'https://example.com',
+```
+
+To use the your application's `app.url` config field, you can set the `short_url.default_url` field to `null`.
 
 ##### Customising the Prefix
 

--- a/config/short-url.php
+++ b/config/short-url.php
@@ -55,6 +55,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Default URL
+    |--------------------------------------------------------------------------
+    |
+    | Here you can override the default application base URL used
+    | to generate the default short URL (default_short_url).
+    |
+    */
+    'default_url' => config('app.url'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Forwards query parameters
     |--------------------------------------------------------------------------
     |

--- a/config/short-url.php
+++ b/config/short-url.php
@@ -58,11 +58,12 @@ return [
     | Default URL
     |--------------------------------------------------------------------------
     |
-    | Here you can override the default application base URL used
-    | to generate the default short URL (default_short_url).
+    | Here you can override the default application base URL used to generate
+    | the default short URL (default_short_url). To use your application's
+    | "app.url" config value, set this field to null.
     |
     */
-    'default_url' => config('app.url'),
+    'default_url' => null,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -651,7 +651,7 @@ class Builder
      */
     private function buildDefaultShortUrl(): string
     {
-        $baseUrl = config('app.url').'/';
+        $baseUrl = config('short-url.default_url', config('app.url')).'/';
 
         if ($this->prefix() !== null) {
             $baseUrl .= $this->prefix().'/';

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -651,7 +651,8 @@ class Builder
      */
     private function buildDefaultShortUrl(): string
     {
-        $baseUrl = config('short-url.default_url', config('app.url')).'/';
+        $baseUrl = config('short-url.default_url') ?? config('app.url');
+        $baseUrl .= '/';
 
         if ($this->prefix() !== null) {
             $baseUrl .= $this->prefix().'/';

--- a/src/Classes/Validation.php
+++ b/src/Classes/Validation.php
@@ -149,6 +149,7 @@ class Validation
      * Validate that the default URL is a valid string or null.
      *
      * @return bool
+     *
      * @throws ValidationException
      */
     protected function validateDefaultUrl(): bool

--- a/src/Classes/Validation.php
+++ b/src/Classes/Validation.php
@@ -21,7 +21,8 @@ class Validation
                && $this->validateDefaultRouteOption()
                && $this->validateKeySalt()
                && $this->validateEnforceHttpsOption()
-               && $this->validateForwardQueryParamsOption();
+               && $this->validateForwardQueryParamsOption()
+               && $this->validateDefaultUrl();
     }
 
     /**
@@ -139,6 +140,24 @@ class Validation
     {
         if (! is_bool(config('short-url.forward_query_params'))) {
             throw new ValidationException('The forward_query_params config variable must be a boolean.');
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that the default URL is a valid string or null.
+     *
+     * @return bool
+     * @throws ValidationException
+     */
+    protected function validateDefaultUrl(): bool
+    {
+        $defaultUrl = config('short-url.default_url');
+        $isValid = is_string($defaultUrl) || is_null($defaultUrl);
+
+        if (! $isValid) {
+            throw new ValidationException('The default_url config variable must be a string or null.');
         }
 
         return true;

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -306,7 +306,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url'              => config('app.url').'/short/customKey',
+            'default_short_url'              => config('short-url.default_url').'/short/customKey',
             'url_key'                        => 'customKey',
             'destination_url'                => 'https://domain.com',
             'track_visits'                   => false,
@@ -334,7 +334,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url'    => config('app.url').'/short/customKey',
+            'default_short_url'    => config('short-url.default_url').'/short/customKey',
             'url_key'              => 'customKey',
             'destination_url'      => 'https://domain.com',
             'track_visits'         => false,
@@ -354,7 +354,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url'    => config('app.url').'/short/customKey',
+            'default_short_url'    => config('short-url.default_url').'/short/customKey',
             'url_key'              => 'customKey',
             'destination_url'      => 'https://domain.com',
             'track_visits'         => false,
@@ -429,7 +429,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url' => config('app.url').'/short/customKey',
+            'default_short_url' => config('short-url.default_url').'/short/customKey',
             'url_key'           => 'customKey',
             'activated_at'      => $activateTime->format('Y-m-d H:i:s'),
             'deactivated_at'    => null,
@@ -449,7 +449,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url' => config('app.url').'/short/customKey',
+            'default_short_url' => config('short-url.default_url').'/short/customKey',
             'url_key'           => 'customKey',
             'activated_at'      => $activateTime->format('Y-m-d H:i:s'),
             'deactivated_at'    => $deactivateTime->format('Y-m-d H:i:s'),
@@ -467,7 +467,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url' => config('app.url').'/short/customKey',
+            'default_short_url' => config('short-url.default_url').'/short/customKey',
             'url_key'           => 'customKey',
             'activated_at'      => now(),
             'deactivated_at'    => $deactivateTime->format('Y-m-d H:i:s'),
@@ -484,7 +484,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url' => config('app.url').'/s/customKey',
+            'default_short_url' => config('short-url.default_url').'/s/customKey',
         ]);
     }
 
@@ -516,7 +516,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url' => config('app.url').'/customKey',
+            'default_short_url' => config('short-url.default_url').'/customKey',
             'url_key' => 'customKey',
         ]);
     }

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -15,6 +15,14 @@ class BuilderTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('short-url.default_url', 'https://short-url.com');
+        Config::set('app.url', 'https://app-url.com');
+    }
+
     /** @test */
     public function exception_is_thrown_in_the_constructor_if_the_config_variables_are_invalid()
     {
@@ -306,7 +314,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url'              => config('short-url.default_url').'/short/customKey',
+            'default_short_url'              => 'https://short-url.com/short/customKey',
             'url_key'                        => 'customKey',
             'destination_url'                => 'https://domain.com',
             'track_visits'                   => false,
@@ -334,7 +342,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url'    => config('short-url.default_url').'/short/customKey',
+            'default_short_url'    => 'https://short-url.com/short/customKey',
             'url_key'              => 'customKey',
             'destination_url'      => 'https://domain.com',
             'track_visits'         => false,
@@ -354,7 +362,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url'    => config('short-url.default_url').'/short/customKey',
+            'default_short_url'    => 'https://short-url.com/short/customKey',
             'url_key'              => 'customKey',
             'destination_url'      => 'https://domain.com',
             'track_visits'         => false,
@@ -429,7 +437,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url' => config('short-url.default_url').'/short/customKey',
+            'default_short_url' => 'https://short-url.com/short/customKey',
             'url_key'           => 'customKey',
             'activated_at'      => $activateTime->format('Y-m-d H:i:s'),
             'deactivated_at'    => null,
@@ -449,7 +457,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url' => config('short-url.default_url').'/short/customKey',
+            'default_short_url' => 'https://short-url.com/short/customKey',
             'url_key'           => 'customKey',
             'activated_at'      => $activateTime->format('Y-m-d H:i:s'),
             'deactivated_at'    => $deactivateTime->format('Y-m-d H:i:s'),
@@ -467,7 +475,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url' => config('short-url.default_url').'/short/customKey',
+            'default_short_url' => 'https://short-url.com/short/customKey',
             'url_key'           => 'customKey',
             'activated_at'      => now(),
             'deactivated_at'    => $deactivateTime->format('Y-m-d H:i:s'),
@@ -484,7 +492,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url' => config('short-url.default_url').'/s/customKey',
+            'default_short_url' => 'https://short-url.com/s/customKey',
         ]);
     }
 
@@ -516,7 +524,7 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertDatabaseHas('short_urls', [
-            'default_short_url' => config('short-url.default_url').'/customKey',
+            'default_short_url' => 'https://short-url.com/customKey',
             'url_key' => 'customKey',
         ]);
     }
@@ -537,5 +545,18 @@ class BuilderTest extends TestCase
             ->make();
 
         $this->assertSame($destination, $shortUrl->destination_url);
+    }
+
+    /** @test */
+    public function app_url_is_set_if_the_default_url_config_value_is_not_set(): void
+    {
+        Config::set('short-url.default_url', null);
+
+        $shortUrl = (new Builder())
+            ->destinationUrl('https://domain.com')
+            ->urlKey('abc123')
+            ->make();
+
+        $this->assertSame('https://app-url.com/short/abc123', $shortUrl->default_short_url);
     }
 }

--- a/tests/Unit/Classes/ResolverTest.php
+++ b/tests/Unit/Classes/ResolverTest.php
@@ -36,7 +36,7 @@ class ResolverTest extends TestCase
 
         $shortURL = ShortURL::create([
             'destination_url'   => 'https://google.com',
-            'default_short_url' => config('app.url').'/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key'           => '12345',
             'single_use'        => true,
             'track_visits'      => true,
@@ -44,7 +44,7 @@ class ResolverTest extends TestCase
 
         ShortURLVisit::create(['short_url_id' => $shortURL->id, 'visited_at' => now()]);
 
-        $request = Request::create(config('app.url').'/short/12345');
+        $request = Request::create(config('short-url.default_url').'/short/12345');
 
         $resolver = new Resolver();
         $resolver->handleVisit($request, $shortURL);
@@ -55,14 +55,14 @@ class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'   => 'https://google.com',
-            'default_short_url' => config('app.url').'/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key'           => '12345',
             'single_use'        => true,
             'track_visits'      => true,
             'activated_at'      => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('app.url').'/short/12345');
+        $request = Request::create(config('short-url.default_url').'/short/12345');
 
         $resolver = new Resolver();
         $result = $resolver->handleVisit($request, $shortURL);
@@ -75,7 +75,7 @@ class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'   => 'https://google.com',
-            'default_short_url' => config('app.url').'/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key'           => '12345',
             'single_use'        => false,
             'track_visits'      => true,
@@ -84,7 +84,7 @@ class ResolverTest extends TestCase
 
         ShortURLVisit::create(['short_url_id' => $shortURL->id, 'visited_at' => now()]);
 
-        $request = Request::create(config('app.url').'/short/12345');
+        $request = Request::create(config('short-url.default_url').'/short/12345');
 
         $resolver = new Resolver();
         $result = $resolver->handleVisit($request, $shortURL);
@@ -96,14 +96,14 @@ class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'   => 'https://google.com',
-            'default_short_url' => config('app.url').'/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key'           => '12345',
             'single_use'        => false,
             'track_visits'      => false,
             'activated_at'      => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('app.url').'/short/12345');
+        $request = Request::create(config('short-url.default_url').'/short/12345');
 
         $resolver = new Resolver();
         $result = $resolver->handleVisit($request, $shortURL);
@@ -125,7 +125,7 @@ class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'                => 'https://google.com',
-            'default_short_url'              => config('app.url').'/short/12345',
+            'default_short_url'              => config('short-url.default_url').'/short/12345',
             'url_key'                        => '12345',
             'single_use'                     => false,
             'track_visits'                   => true,
@@ -139,7 +139,7 @@ class ResolverTest extends TestCase
             'activated_at'                   => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('app.url').'/short/12345');
+        $request = Request::create(config('short-url.default_url').'/short/12345');
 
         // Mock the Agent class so that we don't have
         // to mock the User-Agent header in the
@@ -176,7 +176,7 @@ class ResolverTest extends TestCase
 
         $shortURL = ShortURL::create([
             'destination_url'                => 'https://google.com',
-            'default_short_url'              => config('app.url').'/short/12345',
+            'default_short_url'              => config('short-url.default_url').'/short/12345',
             'url_key'                        => '12345',
             'single_use'                     => false,
             'track_visits'                   => true,
@@ -190,7 +190,7 @@ class ResolverTest extends TestCase
             'activated_at'                   => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('app.url').'/short/12345', 'GET', [], [], [], [
+        $request = Request::create(config('short-url.default_url').'/short/12345', 'GET', [], [], [], [
             'HTTP_referer' => 'https://google.com',
         ]);
 
@@ -226,14 +226,14 @@ class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'   => 'https://google.com',
-            'default_short_url' => config('app.url').'/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key'           => '12345',
             'single_use'        => true,
             'track_visits'      => false,
             'activated_at'      => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('app.url').'/short/12345');
+        $request = Request::create(config('short-url.default_url').'/short/12345');
 
         $resolver = new Resolver();
 
@@ -251,7 +251,7 @@ class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'                => 'https://google.com',
-            'default_short_url'              => config('app.url').'/short/12345',
+            'default_short_url'              => config('short-url.default_url').'/short/12345',
             'url_key'                        => '12345',
             'single_use'                     => false,
             'track_visits'                   => true,
@@ -265,7 +265,7 @@ class ResolverTest extends TestCase
             'activated_at'                   => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('app.url').'/short/12345', 'GET', [], [], [], [
+        $request = Request::create(config('short-url.default_url').'/short/12345', 'GET', [], [], [], [
             'HTTP_referer' => 'https://google.com',
         ]);
 
@@ -297,7 +297,7 @@ class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'                => 'https://google.com',
-            'default_short_url'              => config('app.url').'/short/12345',
+            'default_short_url'              => config('short-url.default_url').'/short/12345',
             'url_key'                        => '12345',
             'single_use'                     => false,
             'track_visits'                   => true,
@@ -311,7 +311,7 @@ class ResolverTest extends TestCase
             'activated_at'                   => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('app.url').'/short/12345', 'GET', [], [], [], [
+        $request = Request::create(config('short-url.default_url').'/short/12345', 'GET', [], [], [], [
             'HTTP_referer' => 'https://google.com',
         ]);
 
@@ -346,7 +346,7 @@ class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'                => 'https://google.com',
-            'default_short_url'              => config('app.url').'/short/12345',
+            'default_short_url'              => config('short-url.default_url').'/short/12345',
             'url_key'                        => '12345',
             'single_use'                     => false,
             'track_visits'                   => false,
@@ -360,7 +360,7 @@ class ResolverTest extends TestCase
             'activated_at'                   => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('app.url').'/short/12345', 'GET', [], [], [], [
+        $request = Request::create(config('short-url.default_url').'/short/12345', 'GET', [], [], [], [
             'HTTP_referer' => 'https://google.com',
         ]);
 

--- a/tests/Unit/Classes/ValidationTest.php
+++ b/tests/Unit/Classes/ValidationTest.php
@@ -116,4 +116,16 @@ class ValidationTest extends TestCase
         $validation = new Validation();
         $validation->validateConfig();
     }
+
+    /** @test */
+    public function exception_is_thrown_if_the_default_url_is_not_a_string(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The default_url config variable must be a string or null.');
+
+        Config::set('short-url.default_url', true);
+
+        $validation = new Validation();
+        $validation->validateConfig();
+    }
 }

--- a/tests/Unit/Controllers/ShortURLControllerEmptyPrefixTest.php
+++ b/tests/Unit/Controllers/ShortURLControllerEmptyPrefixTest.php
@@ -19,7 +19,7 @@ class ShortURLControllerEmptyPrefixTest extends TestCase
     {
         ShortURL::create([
             'destination_url'      => 'https://google.com',
-            'default_short_url'    => config('app.url').'/12345',
+            'default_short_url'    => config('short-url.default_url').'/12345',
             'url_key'              => '12345',
             'single_use'           => true,
             'track_visits'         => true,

--- a/tests/Unit/Controllers/ShortURLControllerPrefixTest.php
+++ b/tests/Unit/Controllers/ShortURLControllerPrefixTest.php
@@ -19,7 +19,7 @@ class ShortURLControllerPrefixTest extends TestCase
     {
         ShortURL::create([
             'destination_url'      => 'https://google.com',
-            'default_short_url'    => config('app.url').'/'.config('short-url.prefix').'/12345',
+            'default_short_url'    => config('short-url.default_url').'/'.config('short-url.prefix').'/12345',
             'url_key'              => '12345',
             'single_use'           => true,
             'track_visits'         => true,

--- a/tests/Unit/Controllers/ShortURLControllerTest.php
+++ b/tests/Unit/Controllers/ShortURLControllerTest.php
@@ -24,7 +24,7 @@ class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url'      => 'https://google.com',
-            'default_short_url'    => config('app.url').'/short/12345',
+            'default_short_url'    => config('short-url.default_url').'/short/12345',
             'url_key'              => '12345',
             'single_use'           => true,
             'track_visits'         => true,
@@ -42,7 +42,7 @@ class ShortURLControllerTest extends TestCase
 
         $shortURL = ShortURL::create([
             'destination_url'                => 'https://google.com',
-            'default_short_url'              => config('app.url').'/short/12345',
+            'default_short_url'              => config('short-url.default_url').'/short/12345',
             'url_key'                        => '12345',
             'single_use'                     => true,
             'forward_query_params'           => false,
@@ -82,7 +82,7 @@ class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url'      => 'https://google.com',
-            'default_short_url'    => config('app.url').'/short/12345',
+            'default_short_url'    => config('short-url.default_url').'/short/12345',
             'url_key'              => '12345',
             'single_use'           => true,
             'track_visits'         => true,
@@ -98,7 +98,7 @@ class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url'      => 'https://google.com',
-            'default_short_url'    => config('app.url').'/short/12345',
+            'default_short_url'    => config('short-url.default_url').'/short/12345',
             'url_key'              => '12345',
             'single_use'           => true,
             'track_visits'         => true,
@@ -115,7 +115,7 @@ class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url'      => 'https://google.com',
-            'default_short_url'    => config('app.url').'/short/12345',
+            'default_short_url'    => config('short-url.default_url').'/short/12345',
             'url_key'              => '12345',
             'single_use'           => true,
             'track_visits'         => true,
@@ -132,7 +132,7 @@ class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url'      => 'https://google.com',
-            'default_short_url'    => config('app.url').'/short/12345',
+            'default_short_url'    => config('short-url.default_url').'/short/12345',
             'url_key'              => '12345',
             'single_use'           => true,
             'track_visits'         => true,
@@ -149,7 +149,7 @@ class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url'      => 'https://google.com?param1=abc',
-            'default_short_url'    => config('app.url').'/short/12345',
+            'default_short_url'    => config('short-url.default_url').'/short/12345',
             'url_key'              => '12345',
             'forward_query_params' => false,
             'redirect_status_code' => 301,

--- a/tests/Unit/Controllers/ShortURLDisableRouteTest.php
+++ b/tests/Unit/Controllers/ShortURLDisableRouteTest.php
@@ -22,7 +22,7 @@ class ShortURLDisableRouteTest extends TestCase
     {
         ShortURL::create([
             'destination_url'      => 'https://google.com',
-            'default_short_url'    => config('app.url').'/short/12345',
+            'default_short_url'    => config('short-url.default_url').'/short/12345',
             'url_key'              => '12345',
             'single_use'           => true,
             'track_visits'         => true,

--- a/tests/Unit/Models/ShortURL/TrackingEnabledTest.php
+++ b/tests/Unit/Models/ShortURL/TrackingEnabledTest.php
@@ -15,7 +15,7 @@ class TrackingEnabledTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'                => 'https://google.com',
-            'default_short_url'              => config('app.url').'/short/12345',
+            'default_short_url'              => config('short-url.default_url').'/short/12345',
             'url_key'                        => '12345',
             'single_use'                     => true,
             'track_visits'                   => true,
@@ -30,7 +30,7 @@ class TrackingEnabledTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'                => 'https://google.com',
-            'default_short_url'              => config('app.url').'/short/12345',
+            'default_short_url'              => config('short-url.default_url').'/short/12345',
             'url_key'                        => '12345',
             'single_use'                     => true,
             'track_visits'                   => false,

--- a/tests/Unit/Models/ShortURL/TrackingFieldsTest.php
+++ b/tests/Unit/Models/ShortURL/TrackingFieldsTest.php
@@ -15,7 +15,7 @@ class TrackingFieldsTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'                => 'https://google.com',
-            'default_short_url'              => config('app.url').'/short/12345',
+            'default_short_url'              => config('short-url.default_url').'/short/12345',
             'url_key'                        => '12345',
             'single_use'                     => true,
             'track_visits'                   => true,
@@ -43,7 +43,7 @@ class TrackingFieldsTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url'                => 'https://google.com',
-            'default_short_url'              => config('app.url').'/short/12345',
+            'default_short_url'              => config('short-url.default_url').'/short/12345',
             'url_key'                        => '12345',
             'single_use'                     => true,
             'track_visits'                   => true,


### PR DESCRIPTION
This PR is to add an option to configure a **default_url** that is used in the **default_short_url** generator.

- Change is backwards-compatible.
- Change offers more flexibility when for example using a Tenancy package.