### PR TITLE
Moved dates to casts for compatibility with Laravel 10

### DIFF
--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -68,18 +68,6 @@ class ShortURL extends Model
     ];
 
     /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = [
-        'activated_at',
-        'deactivated_at',
-        'created_at',
-        'updated_at',
-    ];
-
-    /**
      * @return Factory<ShortURL>
      */
     protected static function newFactory()
@@ -107,6 +95,8 @@ class ShortURL extends Model
         'track_browser_version'          => 'boolean',
         'track_referer_url'              => 'boolean',
         'track_device_type'              => 'boolean',
+        'activated_at'                   => 'datetime',
+        'deactivated_at'                 => 'datetime',
     ];
 
     /**

--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -68,6 +68,20 @@ class ShortURL extends Model
     ];
 
     /**
+     * The attributes that should be mutated to dates.
+     *
+     * @deprecated This field is no longer used in Laravel 10 and above.
+     *             It will be removed in a future release.
+     * @var array
+     */
+    protected $dates = [
+        'activated_at',
+        'deactivated_at',
+        'created_at',
+        'updated_at',
+    ];
+
+    /**
      * @return Factory<ShortURL>
      */
     protected static function newFactory()

--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -72,6 +72,7 @@ class ShortURL extends Model
      *
      * @deprecated This field is no longer used in Laravel 10 and above.
      *             It will be removed in a future release.
+     *
      * @var array
      */
     protected $dates = [

--- a/src/Models/ShortURLVisit.php
+++ b/src/Models/ShortURLVisit.php
@@ -65,6 +65,7 @@ class ShortURLVisit extends Model
      *
      * @deprecated This field is no longer used in Laravel 10 and above.
      *             It will be removed in a future release.
+     *
      * @var array
      */
     protected $dates = [

--- a/src/Models/ShortURLVisit.php
+++ b/src/Models/ShortURLVisit.php
@@ -67,7 +67,7 @@ class ShortURLVisit extends Model
      */
     protected $casts = [
         'short_url_id' => 'integer',
-        'visited_at',  => 'datetime',
+        'visited_at'   => 'datetime',
     ];
 
     /**

--- a/src/Models/ShortURLVisit.php
+++ b/src/Models/ShortURLVisit.php
@@ -61,6 +61,19 @@ class ShortURLVisit extends Model
     ];
 
     /**
+     * The attributes that should be mutated to dates.
+     *
+     * @deprecated This field is no longer used in Laravel 10 and above.
+     *             It will be removed in a future release.
+     * @var array
+     */
+    protected $dates = [
+        'visited_at',
+        'created_at',
+        'updated_at',
+    ];
+
+    /**
      * The attributes that should be cast to native types.
      *
      * @var array<string, string>

--- a/src/Models/ShortURLVisit.php
+++ b/src/Models/ShortURLVisit.php
@@ -61,23 +61,13 @@ class ShortURLVisit extends Model
     ];
 
     /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = [
-        'visited_at',
-        'created_at',
-        'updated_at',
-    ];
-
-    /**
      * The attributes that should be cast to native types.
      *
      * @var array<string, string>
      */
     protected $casts = [
         'short_url_id' => 'integer',
+        'visited_at',  => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
As the title says, this is just a small change that moves the `dates` property to the `$casts` property . It was deprecated in an earlier release and has been removed for Laravel 10. 

Here is the relevant entry in the upgrade guide:
https://laravel.com/docs/10.x/upgrade#model-dates-property