### PR TITLE
Allow hashids/hashids v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "illuminate/container": "^8.0|^9.0|^10.0",
     "illuminate/database": "^8.0|^9.0|^10.0",
     "jenssegers/agent": "^2.6",
-    "hashids/hashids": "^4.0"
+    "hashids/hashids": "^4.0|^5.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -170,9 +170,9 @@ class Builder
             $validation = new Validation();
         }
 
-        $this->keyGenerator = $keyGenerator ?? new KeyGenerator();
-
         $validation->validateConfig();
+
+        $this->keyGenerator = $keyGenerator ?? new KeyGenerator();
     }
 
     /**


### PR DESCRIPTION
This PR just allows for v5 of `hashids/hashids` to be used. v5 mostly adds types ([changelog](https://github.com/vinkla/hashids/blob/master/CHANGELOG.md)). It also removes support for PHP 8.0, which your library still supports. I wasn't sure how you'd like to handle that, so I haven't upgraded `composer.json` to `8.1` yet, but can obviously still do that.

There was one failing test after upgrading the hashids package due to the fact that the key generator was instantiated before the config values were validated and the type check for the key length then failed. I fixed those by validating first and then instantiating the generator after that. I guess it makes more sense this way anyways.