### PR TITLE
Just use mt_rand() to find a valid key

### DIFF
--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -24,62 +24,18 @@ class KeyGenerator
     }
 
     /**
-     * Generate a unique and random URL key using the
-     * Hashids package. We start by predicting the
-     * unique ID that the ShortURL will have in
-     * the database. Then we can encode the ID
-     * to create a unique hash. On the very
-     * unlikely chance that a generated
-     * key collides with another key,
-     * we increment the ID and then
-     * attempt to create a new
-     * unique key again.
+     * Hunt for a valid url_key using mt_rand()
      *
      * @return string
      */
     public function generateRandom(): string
     {
-        $ID = $this->getLastInsertedID();
 
         do {
-            $ID++;
-            $key = $this->hashids->encode($ID);
+            $key = $this->hashids->encode(mt_rand());
         } while (ShortURL::where('url_key', $key)->exists());
 
         return $key;
     }
 
-    /**
-     * Generate a key for the short URL. This method allows you to pass a
-     * seed value to the key generator. If no seed is passed, a random
-     * key will be generated.
-     *
-     * @param  int|null  $seed
-     * @return string
-     */
-    public function generateKeyUsing(int $seed = null): string
-    {
-        return $seed
-            ? $this->hashids->encode($seed)
-            : $this->generateRandom();
-    }
-
-    /**
-     * Get the ID of the last inserted ShortURL. This
-     * is done so that we can predict what the ID of
-     * the ShortURL that will be inserted will be
-     * called. From doing this, we can create a
-     * unique hash without a reduced chance of
-     * a collision.
-     *
-     * @return int
-     */
-    protected function getLastInsertedID(): int
-    {
-        if ($lastInserted = ShortURL::latest()->select('id')->first()) {
-            return $lastInserted->id;
-        }
-
-        return 0;
-    }
 }


### PR DESCRIPTION
After noticing HUGE response time increases (10+ seconds for this do/while loop alone) on a project using this library I found this class was taking a VERY long time to look up url_keys.  After 150k url_keys were already saved into the DB it was iterating over the do/while loop in this over 1500 times on average to find a key and it was only increasing as the keyspace became more occupied (though insignificantly so occupied).  

Sequential key lookup like this was resulting in an unacceptable number of collisions and therefore retries within this class.  Attempts to fix the sequential lookup resulted in similarly bad performance.  I suspect the sequential key lookup (sequential seed anyway) was causing the collisions.  

Simplifying to mt_rand() fixed the issue well beyond 5 million unique keys, maintaining nearly constant generation time past 5 million keys.

Just submitting this PR as food for thought.  I may also try to fix the sequential-style lookup, as that would benefit smaller keyspaces a lot more than the default keyspace.