### PR TITLE
Abstracting the KeyGenerator

### DIFF
--- a/src/Classes/AbstractKeyGenerator.php
+++ b/src/Classes/AbstractKeyGenerator.php
@@ -2,7 +2,7 @@
 
 namespace AshAllenDesign\ShortURL\Classes;
 
-use Hashids\HashidsInterface;
+use Hashids\Hashids;
 
 abstract class AbstractKeyGenerator
 {
@@ -17,7 +17,7 @@ abstract class AbstractKeyGenerator
     /**
      * KeyGenerator constructor.
      */
-    abstract public function __construct(HashidsInterface $hashids = null);
+    abstract public function __construct(Hashids $hashids = null);
 
     /**
      * Generate a unique and random URL key

--- a/src/Classes/AbstractKeyGenerator.php
+++ b/src/Classes/AbstractKeyGenerator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AshAllenDesign\ShortURL\Classes;
+
+use Hashids\HashidsInterface;
+
+abstract class AbstractKeyGenerator
+{
+    /**
+     * The library class that is used for generating
+     * the unique hash.
+     *
+     * @var HashidsInterface
+     */
+    private $hashids;
+
+    /**
+     * KeyGenerator constructor.
+     */
+    abstract public function __construct(HashidsInterface $hashids = null);
+
+    /**
+     * Generate a unique and random URL key
+     *
+     * @return string
+     */
+    abstract public function generateRandom(): string;
+
+    /**
+     * Generate a key for the short URL using a seed value.
+     *
+     * @param  int|null  $seed
+     * @return string
+     */
+    abstract public function generateKeyUsing(int $seed = null): string;
+
+}

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -172,7 +172,7 @@ class Builder
      *
      * @throws ValidationException
      */
-    public function __construct(Validation $validation = null, KeyGenerator $keyGenerator = null)
+    public function __construct(Validation $validation = null, AbstractKeyGenerator $keyGenerator = null)
     {
         if (! $validation) {
             $validation = new Validation();

--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -5,7 +5,7 @@ namespace AshAllenDesign\ShortURL\Classes;
 use AshAllenDesign\ShortURL\Models\ShortURL;
 use Hashids\Hashids;
 
-class KeyGenerator
+class KeyGenerator extends AbstractKeyGenerator
 {
     /**
      * The library class that is used for generating


### PR DESCRIPTION
Turns out abstracting this to allow a user-defined KeyGenerator was extremely simple.  With this PR a user can simply pass their own class that extends the AbstractKeyGenerator into the Builder constructor.

```
   $customKeygen = new CustomKeyGenerator();
   $builder = new Builder(null, $customKeygen);
```

Again, this is just food for thought.  Apologies for the sudden inundation.  I have just wrapped this up, stress tested and will likely not revisit this so I figured I'd provide a final update.