### PR TITLE
Huge performance improvement using timestamps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "laravel-package"
   ],
   "require": {
-    "php": "^8.0",
+    "php": "^7.4|^8.0",
     "nesbot/carbon": "~2.0",
     "illuminate/container": "^8.0",
     "illuminate/database": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "laravel-package"
   ],
   "require": {
-    "php": "^7.4|^8.0",
+    "php": "^8.0",
     "nesbot/carbon": "~2.0",
     "illuminate/container": "^8.0|^9.0|^10.0",
     "illuminate/database": "^8.0|^9.0|^10.0",

--- a/config/short-url.php
+++ b/config/short-url.php
@@ -1,5 +1,10 @@
 <?php
 
+use AshAllenDesign\ShortURL\Models\Factories\ShortURLFactory;
+use AshAllenDesign\ShortURL\Models\Factories\ShortURLVisitFactory;
+use AshAllenDesign\ShortURL\Models\ShortURL;
+use AshAllenDesign\ShortURL\Models\ShortURLVisit;
+
 return [
 
     /*
@@ -34,8 +39,8 @@ return [
     |
     */
     'factories' => [
-        \AshAllenDesign\ShortURL\Models\ShortURL::class => \AshAllenDesign\ShortURL\Models\Factories\ShortURLFactory::class,
-        \AshAllenDesign\ShortURL\Models\ShortURLVisit::class => \AshAllenDesign\ShortURL\Models\Factories\ShortURLVisitFactory::class,
+        ShortURL::class => ShortURLFactory::class,
+        ShortURLVisit::class => ShortURLVisitFactory::class,
     ],
 
     /*
@@ -91,7 +96,7 @@ return [
     | method.
     |
     */
-    'enforce_https'         => true,
+    'enforce_https' => true,
 
     /*
     |--------------------------------------------------------------------------
@@ -111,7 +116,7 @@ return [
     |       used, a 4 character long key will be created.
     |
     */
-    'key_length'            => 5,
+    'key_length' => 5,
 
     /*
     |--------------------------------------------------------------------------
@@ -123,7 +128,7 @@ return [
     | generated keys are unique.
     |
     */
-    'key_salt'              => 'AshAllenDesign\ShortURL',
+    'key_salt' => 'AshAllenDesign\ShortURL',
 
     /*
     |--------------------------------------------------------------------------
@@ -135,7 +140,7 @@ return [
     | and cannot contain spaces.
     |
     */
-    'alphabet'              => 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
+    'alphabet' => 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
 
     /*
     |--------------------------------------------------------------------------
@@ -148,17 +153,17 @@ return [
     | be overridden when creating a short URL.
     |
     */
-    'tracking'              => [
+    'tracking' => [
         'default_enabled' => true,
 
         'fields' => [
-            'ip_address'               => true,
-            'operating_system'         => true,
+            'ip_address' => true,
+            'operating_system' => true,
             'operating_system_version' => true,
-            'browser'                  => true,
-            'browser_version'          => true,
-            'referer_url'              => true,
-            'device_type'              => true,
+            'browser' => true,
+            'browser_version' => true,
+            'referer_url' => true,
+            'device_type' => true,
         ],
     ],
 
@@ -173,4 +178,16 @@ return [
     |
     */
     'validate_config' => false,
+
+    /*
+     |-------------------------------------------------------------------------
+     | Configure unique URL key generation method
+     |-------------------------------------------------------------------------
+     |Choose whether you want URL keys to be generated from timestamps
+     |or from the last ID of ULRs in the database.
+     | using timestamps can improve performance by a huge margin as it
+     |would skip all expensive database queries used in determining the
+     |last and unique
+     */
+    'use_timestamp'=>false
 ];

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -167,14 +167,14 @@ class Builder
      * When constructing this class, ensure that the
      * config variables are validated.
      *
-     * @param  Validation|null  $validation
-     * @param  KeyGenerator|null  $keyGenerator
+     * @param Validation|null $validation
+     * @param KeyGenerator|null $keyGenerator
      *
      * @throws ValidationException
      */
     public function __construct(Validation $validation = null, KeyGenerator $keyGenerator = null)
     {
-        if (! $validation) {
+        if (!$validation) {
             $validation = new Validation();
         }
 
@@ -218,7 +218,7 @@ class Builder
     {
         Route::middleware($this->middleware())->group(function (): void {
             Route::get(
-                '/'.$this->prefix().'/{shortURLKey}',
+                '/' . $this->prefix() . '/{shortURLKey}',
                 ShortURLController::class
             )->name('short-url.invoke');
         });
@@ -228,14 +228,14 @@ class Builder
      * Set the destination URL that the shortened URL
      * will redirect to.
      *
-     * @param  string  $url
+     * @param string $url
      * @return Builder
      *
      * @throws ShortURLException
      */
     public function destinationUrl(string $url): self
     {
-        if (! Str::startsWith($url, ['http://', 'https://'])) {
+        if (!Str::startsWith($url, ['http://', 'https://'])) {
             throw new ShortURLException('The destination URL must begin with http:// or https://');
         }
 
@@ -248,7 +248,7 @@ class Builder
      * Set whether if the shortened URL can be accessed
      * more than once.
      *
-     * @param  bool  $isSingleUse
+     * @param bool $isSingleUse
      * @return Builder
      */
     public function singleUse(bool $isSingleUse = true): self
@@ -262,7 +262,7 @@ class Builder
      * Set whether if the destination URL and shortened
      * URL should be forced to use HTTPS.
      *
-     * @param  bool  $isSecure
+     * @param bool $isSecure
      * @return Builder
      */
     public function secure(bool $isSecure = true): self
@@ -276,7 +276,7 @@ class Builder
      * Set whether if the short URL should forward
      * query params to the destination URL.
      *
-     * @param  bool  $shouldForwardQueryParams
+     * @param bool $shouldForwardQueryParams
      * @return Builder
      */
     public function forwardQueryParams(bool $shouldForwardQueryParams = true): self
@@ -290,7 +290,7 @@ class Builder
      * Set whether if the short URL should track some
      * statistics of the visitors.
      *
-     * @param  bool  $trackUrlVisits
+     * @param bool $trackUrlVisits
      * @return $this
      */
     public function trackVisits(bool $trackUrlVisits = true): self
@@ -304,7 +304,7 @@ class Builder
      * Set whether if the short URL should track the
      * IP address of the visitor.
      *
-     * @param  bool  $track
+     * @param bool $track
      * @return $this
      */
     public function trackIPAddress(bool $track = true): self
@@ -318,7 +318,7 @@ class Builder
      * Set whether if the short URL should track the
      * operating system of the visitor.
      *
-     * @param  bool  $track
+     * @param bool $track
      * @return $this
      */
     public function trackOperatingSystem(bool $track = true): self
@@ -332,7 +332,7 @@ class Builder
      * Set whether if the short URL should track the
      * operating system version of the visitor.
      *
-     * @param  bool  $track
+     * @param bool $track
      * @return $this
      */
     public function trackOperatingSystemVersion(bool $track = true): self
@@ -346,7 +346,7 @@ class Builder
      * Set whether if the short URL should track the
      * browser of the visitor.
      *
-     * @param  bool  $track
+     * @param bool $track
      * @return $this
      */
     public function trackBrowser(bool $track = true): self
@@ -360,7 +360,7 @@ class Builder
      * Set whether if the short URL should track the
      * browser version of the visitor.
      *
-     * @param  bool  $track
+     * @param bool $track
      * @return $this
      */
     public function trackBrowserVersion(bool $track = true): self
@@ -374,7 +374,7 @@ class Builder
      * Set whether if the short URL should track the
      * referer URL of the visitor.
      *
-     * @param  bool  $track
+     * @param bool $track
      * @return $this
      */
     public function trackRefererURL(bool $track = true): self
@@ -388,7 +388,7 @@ class Builder
      * Set whether if the short URL should track the
      * device type of the visitor.
      *
-     * @param  bool  $track
+     * @param bool $track
      * @return $this
      */
     public function trackDeviceType(bool $track = true): self
@@ -401,7 +401,7 @@ class Builder
     /**
      * Explicitly set a URL key for this short URL.
      *
-     * @param  string  $key
+     * @param string $key
      * @return $this
      */
     public function urlKey(string $key): self
@@ -414,7 +414,7 @@ class Builder
     /**
      * Explicitly set the key generator.
      *
-     * @param  KeyGenerator  $keyGenerator
+     * @param KeyGenerator $keyGenerator
      * @return $this
      */
     public function keyGenerator(KeyGenerator $keyGenerator): self
@@ -428,7 +428,7 @@ class Builder
      * Override the HTTP status code that will be used
      * for redirecting the visitor.
      *
-     * @param  int  $statusCode
+     * @param int $statusCode
      * @return $this
      *
      * @throws ShortURLException
@@ -448,7 +448,7 @@ class Builder
      * Set the date and time that the short URL should
      * be activated and allowed to visit.
      *
-     * @param  Carbon  $activationTime
+     * @param Carbon $activationTime
      * @return $this
      *
      * @throws ShortURLException
@@ -468,7 +468,7 @@ class Builder
      * Set the date and time that the short URL should
      * be deactivated and not allowed to visit.
      *
-     * @param  Carbon  $deactivationTime
+     * @param Carbon $deactivationTime
      * @return $this
      *
      * @throws ShortURLException
@@ -504,7 +504,7 @@ class Builder
      */
     public function make(): ShortURL
     {
-        if (! $this->destinationUrl) {
+        if (!$this->destinationUrl) {
             throw new ShortURLException('No destination URL has been set.');
         }
 
@@ -529,22 +529,22 @@ class Builder
         $this->setOptions();
 
         return [
-            'destination_url'                => $this->destinationUrl,
-            'default_short_url'              => $this->buildDefaultShortUrl(),
-            'url_key'                        => $this->urlKey,
-            'single_use'                     => $this->singleUse,
-            'forward_query_params'           => $this->forwardQueryParams,
-            'track_visits'                   => $this->trackVisits,
-            'redirect_status_code'           => $this->redirectStatusCode,
-            'track_ip_address'               => $this->trackIPAddress,
-            'track_operating_system'         => $this->trackOperatingSystem,
+            'destination_url' => $this->destinationUrl,
+            'default_short_url' => $this->buildDefaultShortUrl(),
+            'url_key' => $this->urlKey,
+            'single_use' => $this->singleUse,
+            'forward_query_params' => $this->forwardQueryParams,
+            'track_visits' => $this->trackVisits,
+            'redirect_status_code' => $this->redirectStatusCode,
+            'track_ip_address' => $this->trackIPAddress,
+            'track_operating_system' => $this->trackOperatingSystem,
             'track_operating_system_version' => $this->trackOperatingSystemVersion,
-            'track_browser'                  => $this->trackBrowser,
-            'track_browser_version'          => $this->trackBrowserVersion,
-            'track_referer_url'              => $this->trackRefererURL,
-            'track_device_type'              => $this->trackDeviceType,
-            'activated_at'                   => $this->activateAt,
-            'deactivated_at'                 => $this->deactivateAt,
+            'track_browser' => $this->trackBrowser,
+            'track_browser_version' => $this->trackBrowserVersion,
+            'track_referer_url' => $this->trackRefererURL,
+            'track_device_type' => $this->trackDeviceType,
+            'activated_at' => $this->activateAt,
+            'deactivated_at' => $this->deactivateAt,
         ];
     }
 
@@ -557,9 +557,13 @@ class Builder
      */
     protected function checkKeyDoesNotExist(): void
     {
-        if (ShortURL::where('url_key', $this->urlKey)->exists()) {
-            throw new ShortURLException('A short URL with this key already exists.');
-        }
+
+
+            if (ShortURL::where('url_key', $this->urlKey)->exists()) {
+                throw new ShortURLException('A short URL with this key already exists.');
+            }
+
+
     }
 
     /**
@@ -580,11 +584,11 @@ class Builder
             $this->forwardQueryParams = config('short-url.forward_query_params') ?? false;
         }
 
-        if (! $this->urlKey) {
+        if (!$this->urlKey) {
             $this->urlKey = $this->keyGenerator->generateKeyUsing($this->generateKeyUsing);
         }
 
-        if (! $this->activateAt) {
+        if (!$this->activateAt) {
             $this->activateAt = now();
         }
 
@@ -670,9 +674,9 @@ class Builder
         $baseUrl .= '/';
 
         if ($this->prefix() !== null) {
-            $baseUrl .= $this->prefix().'/';
+            $baseUrl .= $this->prefix() . '/';
         }
 
-        return $baseUrl.$this->urlKey;
+        return $baseUrl . $this->urlKey;
     }
 }

--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -4,6 +4,7 @@ namespace AshAllenDesign\ShortURL\Classes;
 
 use AshAllenDesign\ShortURL\Models\ShortURL;
 use Hashids\Hashids;
+use Illuminate\Support\Carbon;
 
 class KeyGenerator
 {
@@ -39,6 +40,20 @@ class KeyGenerator
      */
     public function generateRandom(): string
     {
+        $useTimestamp = config('short.use_timestamp');
+
+        /**
+         * if this config is set to true it will skip all the queries below
+         * making it faster and less prone to n+1 performance issues
+         */
+
+        if ($useTimestamp){
+
+            return $this->hashids->encode(Carbon::now()->timestamp);
+
+        }
+
+
         $ID = $this->getLastInsertedID();
 
         do {
@@ -47,6 +62,8 @@ class KeyGenerator
         } while (ShortURL::where('url_key', $key)->exists());
 
         return $key;
+
+
     }
 
     /**
@@ -82,4 +99,8 @@ class KeyGenerator
 
         return 0;
     }
+
+
+
+
 }


### PR DESCRIPTION
We use this library at work, great work here as it saved as a ton of work.
we recently recorded a large number of  URLs and i notice a performance issue after months of investigation only to realize that it was from this code, there is an eventual n+1 issue in the method used to get a unique key because you are running queries in a loop meaning as the records grow the slower it gets, secondly for a high traffic app this did not fix our unique key issue as shown below, getting rid of this loop can increase performance by a great margin which i did using timestamps.

       $ID = $this->getLastInsertedID();

        do {
            $ID++;
            $key = $this->hashids->encode($ID);
        } while (ShortURL::where('url_key', $key)->exists());

        return $key;

# Changes 
To make this a choice for now even though i believe this should be the default behavior, users can set the use_timestamp option in the config file.

    /*
     |-------------------------------------------------------------------------
     | Configure unique URL key generation method
     |-------------------------------------------------------------------------
     |Choose whether you want URL keys to be generated from timestamps
     |or from the last ID of ULRs in the database.
     | using timestamps can improve performance by a huge margin as it
     |would skip all expensive database queries used in determining the
     |last and unique
     */
     'use_timestamp'=>false
 

using this option i am able to skip the queries in the loop increasing performance by more than 200X in large datasets as shown below.


    public function generateRandom(): string
    {
        $useTimestamp = config('short.use_timestamp');

        /**
         * if this config is set to true it will skip all the queries below
         * making it faster and less prone to n+1 performance issues
         */

        if ($useTimestamp){

            return $this->hashids->encode(Carbon::now()->timestamp);

        }


        $ID = $this->getLastInsertedID();

        do {
            $ID++;
            $key = $this->hashids->encode($ID);
        } while (ShortURL::where('url_key', $key)->exists());

        return $key;


    }


# my current implementation 

incase this pull request is not merged and you want to boost performance when using this library you can implement it like i did as shown below


        $builder = new Builder();

        $shortURLObject = $builder->destinationUrl($link)
            
            ->generateKeyUsing(Carbon::now()->timestamp)
            
            ->redirectStatusCode(302)->make();
        
        
you can override how the key is generated by passing a timestamp and this can fix the performance issue.



