### PR TITLE
Make short url instance available in middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,8 @@ You can also use this same approach to define middleware groups rather than indi
 ],
 ```
 
+You can access the current `ShortURL` instance in the middleware through `$request->get('shortURL')`.
+
 It's important to note that this middleware will only be automatically applied to the default short URL route that ships with the package. If you are defining your own route, you'll need to apply this middleware to your route yourself.
 
 #### Disabling the Default Route

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -2,6 +2,7 @@
 
 namespace AshAllenDesign\ShortURL\Classes;
 
+use AshAllenDesign\ShortURL\Middleware\ShortURLMiddleware;
 use AshAllenDesign\ShortURL\Controllers\ShortURLController;
 use AshAllenDesign\ShortURL\Exceptions\ShortURLException;
 use AshAllenDesign\ShortURL\Exceptions\ValidationException;
@@ -206,7 +207,7 @@ class Builder
      */
     public function middleware(): array
     {
-        return config('short-url.middleware', []);
+        return [ShortURLMiddleware::class, ...config('short-url.middleware', [])];
     }
 
     /**

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -2,10 +2,10 @@
 
 namespace AshAllenDesign\ShortURL\Classes;
 
-use AshAllenDesign\ShortURL\Middleware\ShortURLMiddleware;
 use AshAllenDesign\ShortURL\Controllers\ShortURLController;
 use AshAllenDesign\ShortURL\Exceptions\ShortURLException;
 use AshAllenDesign\ShortURL\Exceptions\ValidationException;
+use AshAllenDesign\ShortURL\Middleware\ShortURLMiddleware;
 use AshAllenDesign\ShortURL\Models\ShortURL;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Route;

--- a/src/Controllers/ShortURLController.php
+++ b/src/Controllers/ShortURLController.php
@@ -16,13 +16,11 @@ class ShortURLController
      *
      * @param  Request  $request
      * @param  Resolver  $resolver
-     * @param  string  $shortURLKey
      * @return RedirectResponse
      */
-    public function __invoke(Request $request, Resolver $resolver, string $shortURLKey): RedirectResponse
+    public function __invoke(Request $request, Resolver $resolver): RedirectResponse
     {
-        $shortURL = ShortURL::where('url_key', $shortURLKey)->firstOrFail();
-
+        $shortURL = $request->get('shortURL');
         $resolver->handleVisit(request(), $shortURL);
 
         if ($shortURL->forward_query_params) {

--- a/src/Middleware/ShortURLMiddleware.php
+++ b/src/Middleware/ShortURLMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AshAllenDesign\ShortURL\Middleware;
+
+use AshAllenDesign\ShortURL\Models\ShortURL;
+use Closure;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class ShortURLMiddleware
+{
+    /**
+     * Set the ShortURL instance as an attribute on the request.
+     *
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @return RedirectResponse
+     */
+    public function handle(Request $request, Closure $next): RedirectResponse
+    {
+        $shortURL = ShortURL::where('url_key', $request->route('shortURLKey'))->firstOrFail();
+        $request->attributes->add(['shortURL' => $shortURL]);
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Hey @ash-jc-allen,

First of all: thanks for your work on this package!
The background for this PR is, that I need to dynamically add query parameters on the destination url. I also need to access the `ShortURL` instance of the link for this.

Although this can already be done by adding a middleware through the `middleware` config option, I would need to query the `ShortURL` instance which is later retrieved again in the `ShortURLController` [here](https://github.com/ash-jc-allen/short-url/blob/664ee84d9df81de7617aec30643e71f69ce79ea3/src/Controllers/ShortURLController.php#L24). In order to prevent executing the same query twice I propose this PR. Furthermore having access to this current `ShortURL` instance makes middlewares way more powerful.