### PR TITLE
Add model fillable attributes to config

### DIFF
--- a/config/short-url.php
+++ b/config/short-url.php
@@ -173,4 +173,52 @@ return [
     |
     */
     'validate_config' => false,
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | ShortURL Model Fillable Attributes
+    |--------------------------------------------------------------------------
+    |
+    | Define which attributes you would like to add to the model
+    |
+    */
+    'short_url_attributes' => [
+        'destination_url',
+        'default_short_url',
+        'url_key',
+        'single_use',
+        'forward_query_params',
+        'track_visits',
+        'redirect_status_code',
+        'track_ip_address',
+        'track_operating_system',
+        'track_operating_system_version',
+        'track_browser',
+        'track_browser_version',
+        'track_referer_url',
+        'track_device_type',
+        'activated_at',
+        'deactivated_at',
+    ],
+
+    /*
+  |--------------------------------------------------------------------------
+  | ShortURLVisit Model Fillable Attributes
+  |--------------------------------------------------------------------------
+  |
+  | Define which attributes you would like to add to the model
+  |
+  */
+    'short_url_visit_attributes' => [
+        'short_url_id',
+        'ip_address',
+        'operating_system',
+        'operating_system_version',
+        'browser',
+        'browser_version',
+        'visited_at',
+        'referer_url',
+        'device_type',
+    ],
 ];

--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -82,6 +82,13 @@ class ShortURL extends Model
         'updated_at',
     ];
 
+
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+        $this->fillable =  config('short-url.short_url_attributes');
+    }
+
     /**
      * @return Factory<ShortURL>
      */

--- a/src/Models/ShortURLVisit.php
+++ b/src/Models/ShortURLVisit.php
@@ -84,6 +84,12 @@ class ShortURLVisit extends Model
         'visited_at'   => 'datetime',
     ];
 
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+        $this->fillable =  config('short-url.short_url_visit_attributes');
+    }
+
     /**
      * @return Factory<ShortURLVisit>
      */


### PR DESCRIPTION
Since the migrations are publishable, it's better to let the user define which fields are fillable. of course the original fillable attributes remains the same in the models and config file, the user can define their own fields, which they can add to the migration files, so adding additional data to the model can be easily achieved by accessing the created model or listening to the fired ShortURLVisited event, or even creating an observer.