### PR TITLE
feat(config): allow override connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
             - [Default Tracking](#default-tracking)
             - [Tracking Fields](#tracking-fields)
         - [Config Validation](#config-validation)
+        - [Custom Database Connection](#custom-database-connection)
     - [Helper Methods](#helper-methods)
         - [Visits](#visits)
         - [Find by URL Key](#find-by-url-key)
@@ -564,6 +565,16 @@ following option in the config:
 ```
 'validate_config' => true,
 ``` 
+
+#### Custom Database Connection
+
+By default, Short URL will use your application's default database connection. But there may be times that you'd like to use a different connection. For example, you might be building a multi-tenant application that uses a separate connection for each tenant, and you may want to store the short URLs in a central database.
+
+To do this, you can set the connection name using the `connection` config value in the `config/short-url.php` file like so:
+
+```
+'connection' => 'custom_database_connection_name',
+```
 
 ### Helper Methods
 #### Visits

--- a/config/short-url.php
+++ b/config/short-url.php
@@ -15,6 +15,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Custom Connection
+    |--------------------------------------------------------------------------
+    |
+    | This configuration value is used to override the connection that
+    | will be used by models of this package. Default: null (no override)
+    |
+    */
+    'connection' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Middleware
     |--------------------------------------------------------------------------
     |

--- a/config/short-url.php
+++ b/config/short-url.php
@@ -15,11 +15,12 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Custom Connection
+    | Custom Database Connection
     |--------------------------------------------------------------------------
     |
-    | This configuration value is used to override the connection that
-    | will be used by models of this package. Default: null (no override)
+    | This configuration value is used to override the database connection
+    | that will be used by models of this package. If set to `null`, your
+    | application's default database connection will be used.
     |
     */
     'connection' => null,

--- a/database/migrations/2019_12_22_015115_create_short_urls_table.php
+++ b/database/migrations/2019_12_22_015115_create_short_urls_table.php
@@ -13,7 +13,7 @@ class CreateShortUrlsTable extends Migration
      */
     public function up()
     {
-        Schema::create('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->create('short_urls', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->text('destination_url');
             $table->string('url_key')->unique();
@@ -31,6 +31,6 @@ class CreateShortUrlsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('short_urls');
+        Schema::connection(config('short-url.connection'))->dropIfExists('short_urls');
     }
 }

--- a/database/migrations/2019_12_22_015214_create_short_url_visits_table.php
+++ b/database/migrations/2019_12_22_015214_create_short_url_visits_table.php
@@ -13,7 +13,7 @@ class CreateShortUrlVisitsTable extends Migration
      */
     public function up()
     {
-        Schema::create('short_url_visits', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->create('short_url_visits', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('short_url_id');
             $table->string('ip_address')->nullable();
@@ -35,6 +35,6 @@ class CreateShortUrlVisitsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('short_url_visits');
+        Schema::connection(config('short-url.connection'))->dropIfExists('short_url_visits');
     }
 }

--- a/database/migrations/2020_02_11_224848_update_short_url_table_for_version_two_zero_zero.php
+++ b/database/migrations/2020_02_11_224848_update_short_url_table_for_version_two_zero_zero.php
@@ -14,7 +14,7 @@ class UpdateShortURLTableForVersionTwoZeroZero extends Migration
      */
     public function up()
     {
-        Schema::table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
             $table->integer('redirect_status_code')->after('track_visits')->default(301);
             $table->boolean('track_ip_address')->after('redirect_status_code')->default(false);
             $table->boolean('track_operating_system')->after('track_ip_address')->default(false);
@@ -43,7 +43,7 @@ class UpdateShortURLTableForVersionTwoZeroZero extends Migration
      */
     public function down()
     {
-        Schema::table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
             $table->dropColumn([
                 'redirect_status_code',
                 'track_ip_address',

--- a/database/migrations/2020_02_12_008432_update_short_url_visits_table_for_version_two_zero_zero.php
+++ b/database/migrations/2020_02_12_008432_update_short_url_visits_table_for_version_two_zero_zero.php
@@ -13,7 +13,7 @@ class UpdateShortURLVisitsTableForVersionTwoZeroZero extends Migration
      */
     public function up()
     {
-        Schema::table('short_url_visits', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table('short_url_visits', function (Blueprint $table) {
             $table->string('referer_url')->after('browser_version')->nullable();
             $table->string('device_type')->after('referer_url')->nullable();
         });
@@ -26,7 +26,7 @@ class UpdateShortURLVisitsTableForVersionTwoZeroZero extends Migration
      */
     public function down()
     {
-        Schema::table('short_url_visits', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table('short_url_visits', function (Blueprint $table) {
             $table->dropColumn(['referer_url', 'device_type']);
         });
     }

--- a/database/migrations/2020_04_10_224546_update_short_url_table_for_version_three_zero_zero.php
+++ b/database/migrations/2020_04_10_224546_update_short_url_table_for_version_three_zero_zero.php
@@ -13,7 +13,7 @@ class UpdateShortURLTableForVersionThreeZeroZero extends Migration
      */
     public function up()
     {
-        Schema::table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
             $table->timestamp('activated_at')->after('track_device_type')->nullable()->default(now());
             $table->timestamp('deactivated_at')->after('activated_at')->nullable();
         });
@@ -26,7 +26,7 @@ class UpdateShortURLTableForVersionThreeZeroZero extends Migration
      */
     public function down()
     {
-        Schema::table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
             $table->dropColumn(['activated_at', 'deactivated_at']);
         });
     }

--- a/database/migrations/2020_04_20_009283_update_short_url_table_add_option_to_forward_query_params.php
+++ b/database/migrations/2020_04_20_009283_update_short_url_table_add_option_to_forward_query_params.php
@@ -13,7 +13,7 @@ class UpdateShortUrlTableAddOptionToForwardQueryParams extends Migration
      */
     public function up()
     {
-        Schema::table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
             $table->boolean('forward_query_params')->after('single_use')->default(false);
         });
     }
@@ -25,7 +25,7 @@ class UpdateShortUrlTableAddOptionToForwardQueryParams extends Migration
      */
     public function down()
     {
-        Schema::table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
             $table->dropColumn(['forward_query_params']);
         });
     }

--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -82,6 +82,15 @@ class ShortURL extends Model
         'updated_at',
     ];
 
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        if (null !== config('short-url.connection')) {
+            $this->setConnection(config('short-url.connection'));
+        }
+    }
+
     /**
      * @return Factory<ShortURL>
      */

--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -86,7 +86,7 @@ class ShortURL extends Model
     {
         parent::__construct($attributes);
 
-        if (null !== config('short-url.connection')) {
+        if (config('short-url.connection')) {
             $this->setConnection(config('short-url.connection'));
         }
     }

--- a/src/Models/ShortURLVisit.php
+++ b/src/Models/ShortURLVisit.php
@@ -88,7 +88,7 @@ class ShortURLVisit extends Model
     {
         parent::__construct($attributes);
 
-        if (null !== config('short-url.connection')) {
+        if (config('short-url.connection')) {
             $this->setConnection(config('short-url.connection'));
         }
     }

--- a/src/Models/ShortURLVisit.php
+++ b/src/Models/ShortURLVisit.php
@@ -84,6 +84,15 @@ class ShortURLVisit extends Model
         'visited_at'   => 'datetime',
     ];
 
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        if (null !== config('short-url.connection')) {
+            $this->setConnection(config('short-url.connection'));
+        }
+    }
+
     /**
      * @return Factory<ShortURLVisit>
      */

--- a/tests/Unit/Models/ShortURL/ShortURLTest.php
+++ b/tests/Unit/Models/ShortURL/ShortURLTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AshAllenDesign\ShortURL\Tests\Unit\Models\ShortURL;
+
+use AshAllenDesign\ShortURL\Models\ShortURL;
+use AshAllenDesign\ShortURL\Tests\Unit\TestCase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+
+final class ShortURLTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    /** @test */
+    public function connection_can_be_overridden(): void
+    {
+        config(['short-url.connection' => 'custom']);
+
+        $this->assertEquals(
+            'custom',
+            (new ShortURL())->getConnectionName(),
+        );
+    }
+
+    /** @test */
+    public function default_connection_is_used_if_the_override_is_not_set(): void
+    {
+        $this->assertNull((new ShortURL())->getConnectionName());
+    }
+}

--- a/tests/Unit/Models/ShortURLVisit/ShortURLVisitTest.php
+++ b/tests/Unit/Models/ShortURLVisit/ShortURLVisitTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AshAllenDesign\ShortURL\Tests\Unit\Models\ShortURLVisit;
+
+use AshAllenDesign\ShortURL\Models\ShortURLVisit;
+use AshAllenDesign\ShortURL\Tests\Unit\TestCase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+
+final class ShortURLVisitTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    /** @test */
+    public function connection_can_be_overridden(): void
+    {
+        config(['short-url.connection' => 'custom']);
+
+        $this->assertEquals(
+            'custom',
+            (new ShortURLVisit())->getConnectionName(),
+        );
+    }
+
+    /** @test */
+    public function default_connection_is_used_if_the_override_is_not_set(): void
+    {
+        $this->assertNull((new ShortURLVisit())->getConnectionName());
+    }
+}


### PR DESCRIPTION
Allow override connection with an option in config/short-url.php without breaking changes.

it is useful when you use this package in an application with more than one connection that changes dynamically (such as a multitenat environment), but you always want to use the same connection