### PR TITLE
Add ability to tap `ShortURL` model before creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ $shortURL = ShortUrlBuilder::destinationUrl($url)
         $model->tenant_id = $tenantId;
     })
     )->make();
-````
+```
 
 Please remember that to store custom fields in the database, you'll have to make sure those fields are added to the `short_urls` table. You can do this by creating a new migration that adds the fields to the table, or by updating the migrations that ship with this package.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
             - [Tracking Operating System & Operating System Version](#tracking-operating-system--operating-system-version)
             - [Tracking Device Type](#tracking-device-type)
             - [Tracking Referer URL](#tracking-referer-url)
+        - [Custom Short URL Fields](#custom-short-url-fields)
         - [Single Use](#single-use)
         - [Enforce HTTPS](#enforce-https)
         - [Forwarding Query Parameters](#forwarding-query-parameters)
@@ -234,6 +235,26 @@ $builder = new \AshAllenDesign\ShortURL\Classes\Builder();
 
 $shortURLObject = $builder->destinationUrl('https://destination.com')->trackVisits()->trackRefererURL()->make();
 ```
+
+#### Custom Short URL Fields
+
+There may be times when you want to add your own custom fields to the ShortURL model and store them in the database. For example, you might want to associate the short URL with a tenant, organisation, user, etc.
+
+To do this you can use the `beforeCreate` method when building your short URL. This method accepts a closure that receives the `AshAllenDesign\ShortURL\Models\ShortURL` model instance before it's saved to your database.
+
+The example below shows how to add a `tenant_id` field to the `AshAllenDesign\ShortURL\Models\ShortURL` model:
+
+```php
+$tenantId = 123;
+
+$shortURL = ShortUrlBuilder::destinationUrl($url)
+    ->beforeCreate(function (ShortURL $model): void {
+        $model->tenant_id = $tenantId;
+    })
+    )->make();
+````
+
+Please remember that to store custom fields in the database, you'll have to make sure those fields are added to the `short_urls` table. You can do this by creating a new migration that adds the fields to the table, or by updating the migrations that ship with this package.
 
 #### Single Use
 By default, all of the shortened URLs can be visited for as long as you leave them available. However, you may want to

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -168,7 +168,7 @@ class Builder
      *
      * @var Closure|null
      */
-    protected ?Closure $beforeCreate = null;
+    protected ?Closure $beforeCreateCallback = null;
 
     /**
      * Builder constructor.
@@ -518,7 +518,7 @@ class Builder
      */
     public function beforeCreate(Closure $callback): self
     {
-        $this->beforeCreate = $callback;
+        $this->beforeCreateCallback = $callback;
 
         return $this;
     }
@@ -542,8 +542,8 @@ class Builder
 
         $shortURL = new ShortURL($data);
 
-        if ($this->beforeCreate) {
-            value($this->beforeCreate, $shortURL);
+        if ($this->beforeCreateCallback) {
+            value($this->beforeCreateCallback, $shortURL);
         }
 
         $shortURL->save();
@@ -692,7 +692,7 @@ class Builder
         $this->activateAt = null;
         $this->deactivateAt = null;
         $this->generateKeyUsing = null;
-        $this->beforeCreate = null;
+        $this->beforeCreateCallback = null;
 
         return $this;
     }

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -514,7 +514,7 @@ class Builder
 
         $this->checkKeyDoesNotExist();
 
-        $shortURL = ShortURL::make($data);
+        $shortURL = new ShortURL($data);
 
         value($callback, $shortURL);
 

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -163,6 +163,14 @@ class Builder
     protected ?int $generateKeyUsing = null;
 
     /**
+     * Define a callback to access the ShortURL
+     * model prior to creation.
+     *
+     * @var Closure|null
+     */
+    protected ?Closure $beforeCreate = null;
+
+    /**
      * Builder constructor.
      *
      * When constructing this class, ensure that the
@@ -489,6 +497,12 @@ class Builder
         return $this;
     }
 
+    /**
+     * Set the seed to be used when generating a short URL key.
+     *
+     * @param int $generateUsing
+     * @return $this
+     */
     public function generateKeyUsing(int $generateUsing): self
     {
         $this->generateKeyUsing = $generateUsing;
@@ -497,14 +511,26 @@ class Builder
     }
 
     /**
+     * Pass the Short URL model into the callback before it is created.
+     *
+     * @param Closure $callback
+     * @return $this
+     */
+    public function beforeCreate(Closure $callback): self
+    {
+        $this->beforeCreate = $callback;
+
+        return $this;
+    }
+
+    /**
      * Attempt to build a shortened URL and return it.
      *
-     * @param Closure|null $callback
      * @return ShortURL
      *
      * @throws ShortURLException
      */
-    public function make(Closure $callback = null): ShortURL
+    public function make(): ShortURL
     {
         if (! $this->destinationUrl) {
             throw new ShortURLException('No destination URL has been set.');
@@ -516,7 +542,9 @@ class Builder
 
         $shortURL = new ShortURL($data);
 
-        value($callback, $shortURL);
+        if ($this->beforeCreate) {
+            value($this->beforeCreate, $shortURL);
+        }
 
         $shortURL->save();
 
@@ -660,6 +688,11 @@ class Builder
         $this->trackBrowserVersion = null;
         $this->trackRefererURL = null;
         $this->trackDeviceType = null;
+
+        $this->activateAt = null;
+        $this->deactivateAt = null;
+        $this->generateKeyUsing = null;
+        $this->beforeCreate = null;
 
         return $this;
     }

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -500,7 +500,7 @@ class Builder
     /**
      * Set the seed to be used when generating a short URL key.
      *
-     * @param int $generateUsing
+     * @param  int  $generateUsing
      * @return $this
      */
     public function generateKeyUsing(int $generateUsing): self
@@ -513,7 +513,7 @@ class Builder
     /**
      * Pass the Short URL model into the callback before it is created.
      *
-     * @param Closure $callback
+     * @param  Closure  $callback
      * @return $this
      */
     public function beforeCreate(Closure $callback): self

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -7,6 +7,7 @@ use AshAllenDesign\ShortURL\Exceptions\ShortURLException;
 use AshAllenDesign\ShortURL\Exceptions\ValidationException;
 use AshAllenDesign\ShortURL\Models\ShortURL;
 use Carbon\Carbon;
+use Closure;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
@@ -498,11 +499,12 @@ class Builder
     /**
      * Attempt to build a shortened URL and return it.
      *
+     * @param Closure|null $callback
      * @return ShortURL
      *
      * @throws ShortURLException
      */
-    public function make(): ShortURL
+    public function make(Closure $callback = null): ShortURL
     {
         if (! $this->destinationUrl) {
             throw new ShortURLException('No destination URL has been set.');
@@ -512,7 +514,11 @@ class Builder
 
         $this->checkKeyDoesNotExist();
 
-        $shortURL = ShortURL::create($data);
+        $shortURL = ShortURL::make($data);
+
+        value($callback, $shortURL);
+
+        $shortURL->save();
 
         $this->resetOptions();
 

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -554,9 +554,10 @@ class BuilderTest extends TestCase
     {
         $shortUrl = (new Builder())
             ->destinationUrl('https://foo.com')
-            ->make(function (ShortURL $shortURL) {
+            ->beforeCreate(function (ShortURL $shortURL) {
                 $shortURL->destination_url = 'https://bar.com';
-            });
+            })
+            ->make();
 
         $this->assertSame('https://bar.com', $shortUrl->destination_url);
     }

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -550,6 +550,18 @@ class BuilderTest extends TestCase
     }
 
     /** @test */
+    public function data_can_be_overridden_on_model_using_make_callback(): void
+    {
+        $shortUrl = (new Builder())
+            ->destinationUrl('https://foo.com')
+            ->make(function (ShortURL $shortURL) {
+                $shortURL->destination_url = 'https://bar.com';
+            });
+
+        $this->assertSame('https://bar.com', $shortUrl->destination_url);
+    }
+
+    /** @test */
     public function app_url_is_set_if_the_default_url_config_value_is_not_set(): void
     {
         Config::set('short-url.default_url', null);


### PR DESCRIPTION
## Description

This PR adds the ability to tap the `ShortURL` model before it is created via a `beforeCreate` method so that additional columns that applications may need can be set.

For example, my application needs to associate Short URL's to companies (via a `company_id`), which I've added to the published `short_urls` table migration. However, there's no way to set this relation during creation, so the `company_id` column must be nullable in the migration, even though it's actually required in my application for each Short URL created.

Adding a callback allows direct access to the `ShortURL` model prior to its creation, so that a `company_id` can be associated and be non-nullable.

## Usage

```php
use AshAllenDesign\ShortURL\Models\ShortURL;
use AshAllenDesign\ShortURL\Facades\ShortURL as ShortUrlBuilder;

// ...

$shortURL = ShortUrlBuilder::destinationUrl($url)->beforeCreate(
    fn (ShortURL $model) => $model->company_id = $companyId
)->make();
```

```php
// Later in my application...

$company->shortUrls()->withCount('visits')->get();
```

Let me know your thoughts and if you'd like anything adjusted! 🙏 