### PR TITLE
Fix casting of forward_query_params

### DIFF
--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -110,7 +110,7 @@ class ShortURL extends Model
      */
     protected $casts = [
         'single_use' => 'boolean',
-        'forward_query_parameters' => 'boolean',
+        'forward_query_params' => 'boolean',
         'track_visits' => 'boolean',
         'track_ip_address' => 'boolean',
         'track_operating_system' => 'boolean',


### PR DESCRIPTION
There is a type that prevents the correct boolean casting of forward_query_params.