### PR TITLE
Add user_id to visit event, if authenticated

### DIFF
--- a/src/Classes/Resolver.php
+++ b/src/Classes/Resolver.php
@@ -61,7 +61,7 @@ class Resolver
 
         $visit = $this->recordVisit($request, $shortURL);
 
-        Event::dispatch(new ShortURLVisited($shortURL, $visit));
+        Event::dispatch(new ShortURLVisited($shortURL, $visit, auth()->id()));
 
         return true;
     }

--- a/src/Events/ShortURLVisited.php
+++ b/src/Events/ShortURLVisited.php
@@ -39,7 +39,7 @@ class ShortURLVisited
      * @param  ShortURL  $shortURL
      * @param  ShortURLVisit  $shortURLVisit
      */
-    public function __construct(ShortURL $shortURL, ShortURLVisit $shortURLVisit, $user)
+    public function __construct(ShortURL $shortURL, ShortURLVisit $shortURLVisit, ?$user)
     {
         $this->shortURL = $shortURL;
         $this->shortURLVisit = $shortURLVisit;


### PR DESCRIPTION
I saw a discussion from a couple years back (2022) talking about adding user tracking, but it being out of scope for this repo. Understandable, but finding myself needing it on the visited event, so adding here.