### PR TITLE
Set user agent columns to `null` when user agent is not available

### DIFF
--- a/src/Classes/Resolver.php
+++ b/src/Classes/Resolver.php
@@ -137,19 +137,19 @@ class Resolver
         }
 
         if ($shortURL->track_operating_system) {
-            $visit->operating_system = $this->agent->platform();
+            $visit->operating_system = $this->agent->platform() ?: null;
         }
 
         if ($shortURL->track_operating_system_version) {
-            $visit->operating_system_version = $this->agent->version($this->agent->platform());
+            $visit->operating_system_version = $this->agent->version($this->agent->platform()) ?: null;
         }
 
         if ($shortURL->track_browser) {
-            $visit->browser = $this->agent->browser();
+            $visit->browser = $this->agent->browser() ?: null;
         }
 
         if ($shortURL->track_browser_version) {
-            $visit->browser_version = $this->agent->version($this->agent->browser());
+            $visit->browser_version = $this->agent->version($this->agent->browser()) ?: null;
         }
 
         if ($shortURL->track_referer_url) {
@@ -165,9 +165,9 @@ class Resolver
      * Guess and return the device type that was used to
      * visit the short URL.
      *
-     * @return string
+     * @return ?string
      */
-    protected function guessDeviceType(): string
+    protected function guessDeviceType(): ?string
     {
         if ($this->agent->isDesktop()) {
             return ShortURLVisit::DEVICE_TYPE_DESKTOP;
@@ -185,6 +185,6 @@ class Resolver
             return ShortURLVisit::DEVICE_TYPE_ROBOT;
         }
 
-        return '';
+        return null;
     }
 }

--- a/src/Models/ShortURLVisit.php
+++ b/src/Models/ShortURLVisit.php
@@ -13,14 +13,14 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $short_url_id
- * @property string $ip_address
- * @property string $operating_system
- * @property string $operating_system_version
- * @property string $browser
- * @property string $browser_version
- * @property string $device_type
+ * @property ?string $ip_address
+ * @property ?string $operating_system
+ * @property ?string $operating_system_version
+ * @property ?string $browser
+ * @property ?string $browser_version
+ * @property ?string $referer_url
+ * @property ?string $device_type
  * @property Carbon $visited_at
- * @property string $referer_url
  * @property Carbon $created_at
  * @property Carbon $updated_at
  */


### PR DESCRIPTION
Closes #243 

This PR implements a fix to properly set the user agent columns to `null` instead of `"0"` when they are not available.

I've also corrected the `ShortURLVisit` model annotations to present these attributes as nullable.

Let me know if you'd like anything adjusted. Thanks for your time!