### PR TITLE
Generate facade docs using official Laravel Facade Documenter

### DIFF
--- a/src/Facades/ShortURL.php
+++ b/src/Facades/ShortURL.php
@@ -2,39 +2,39 @@
 
 namespace AshAllenDesign\ShortURL\Facades;
 
-use AshAllenDesign\ShortURL\Classes\Builder;
-use AshAllenDesign\ShortURL\Classes\KeyGenerator;
-use Carbon\Carbon;
 use Illuminate\Support\Facades\Facade;
 use RuntimeException;
 
 /**
- * @method static self destinationUrl(string $url)
- * @method static self singleUse(bool $isSingleUse = true)
- * @method static self secure(bool $isSecure = true)
- * @method static self forwardQueryParams(bool $shouldForwardQueryParams = true)
- * @method static self trackVisits(bool $trackVisits = true)
- * @method static self trackIPAddress(bool $track)
- * @method static self trackOperatingSystem(bool $track)
- * @method static self trackOperatingSystemVersion(bool $track)
- * @method static self trackBrowser(bool $track)
- * @method static self trackBrowserVersion(bool $track)
- * @method static self trackRefererURL(bool $track)
- * @method static self trackDeviceType(bool $track)
- * @method static self urlKey(string $key)
- * @method static self keyGenerator(KeyGenerator $keyGenerator)
- * @method static self redirectStatusCode(int $statusCode)
- * @method static self resetOptions()
- * @method static self activateAt(Carbon $activationTime)
- * @method static self deactivateAt(Carbon $deactivationTime)
- * @method static self beforeCreate(Closure $callback)
- * @method static \AshAllenDesign\ShortURL\Models\ShortURL make()
  * @method static string|null prefix()
  * @method static array middleware()
- * @method static array toArray()
  * @method static void routes()
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder destinationUrl(string $url)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder singleUse(bool $isSingleUse = true)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder secure(bool $isSecure = true)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder forwardQueryParams(bool $shouldForwardQueryParams = true)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder trackVisits(bool $trackUrlVisits = true)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder trackIPAddress(bool $track = true)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder trackOperatingSystem(bool $track = true)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder trackOperatingSystemVersion(bool $track = true)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder trackBrowser(bool $track = true)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder trackBrowserVersion(bool $track = true)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder trackRefererURL(bool $track = true)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder trackDeviceType(bool $track = true)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder urlKey(string $key)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder keyGenerator(\AshAllenDesign\ShortURL\Classes\KeyGenerator $keyGenerator)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder redirectStatusCode(int $statusCode)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder activateAt(\Carbon\Carbon $activationTime)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder deactivateAt(\Carbon\Carbon $deactivationTime)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder generateKeyUsing(int $generateUsing)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder beforeCreate(\Closure $callback)
+ * @method static \AshAllenDesign\ShortURL\Models\ShortURL make()
+ * @method static array toArray()
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder resetOptions()
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
+ * @method static \AshAllenDesign\ShortURL\Classes\Builder|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  *
- * @see Builder
+ * @see \AshAllenDesign\ShortURL\Classes\Builder
  */
 class ShortURL extends Facade
 {


### PR DESCRIPTION
While building URL's I noticed some methods were missing (such as the `Conditionable` trait methods, `generateKeyUsing`, etc.) and some return types being incorrect (returning `self` instead of `Builder`), so I generated the annotations using Laravel's official [Facade Documenter](https://github.com/laravel/facade-documenter) via the below:

```bash
composer require stevebauman/autodoc-facades --dev
```

```bash
php -f vendor/bin/facade.php -- \
    AshAllenDesign\\ShortURL\\Facades\\ShortURL
```

```bash
composer remove stevebauman/autodoc-facades
```

Let me know if you'd like anything changed/adjusted. Thanks for your time! 🙏 