### PR TITLE
Custom Tables and Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,44 @@ following option in the config:
 'validate_config' => true,
 ``` 
 
+#### Custom Tables and Models
+
+By default, the package will use the `short_urls` and `short_url_visits` tables and the `ShortURL` and `ShortURLVisit` models. However, you may want to use your own custom tables and models.
+
+To do this, you can set the connection name using the `urls_model`, `urls_table`, `visits_model` and `visits_table`' config value in the `config/short-url.php` file like so:
+
+```
+'urls_model' => \AshAllenDesign\ShortURL\Models\ShortURL::class,
+'urls_table' => 'short_urls',
+
+'visits_model' => \AshAllenDesign\ShortURL\Models\ShortURLVisit::class,
+'visits_table' => 'short_url_visits',
+```
+
+And then create your own models that extend the package's models:
+
+```php
+namespace App\Models;
+
+use AshAllenDesign\ShortURL\Models\ShortURL as ShortURLModel;
+
+class ShortURL extends ShortURLModel
+{
+    // Your custom code here.
+}
+```
+
+```php
+namespace App\Models;
+
+use AshAllenDesign\ShortURL\Models\ShortURLVisit as ShortURLVisitModel;
+
+class ShortURLVisit extends ShortURLVisitModel
+{
+    // Your custom code here.
+}
+```
+
 #### Custom Database Connection
 
 By default, Short URL will use your application's default database connection. But there may be times that you'd like to use a different connection. For example, you might be building a multi-tenant application that uses a separate connection for each tenant, and you may want to store the short URLs in a central database.

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
   "type": "library",
   "homepage": "https://github.com/c-delouvencourt/short-url",
   "license": "MIT",
+  "version": "1.0.0",
   "authors": [
     {
       "name": "Ash Allen",

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-  "name": "c-delouvencourt/short-url",
+  "name": "ashallendesign/short-url",
   "description": "A Laravel package for creating shortened URLs for your web apps.",
   "type": "library",
-  "homepage": "https://github.com/c-delouvencourt/short-url",
+  "homepage": "https://github.com/ash-jc-allen/short-url",
   "license": "MIT",
   "authors": [
     {
-      "name": "Clément de Louvencourt",
-      "email": "clement@meilleursbiens.com"
+      "name": "Ash Allen",
+      "email": "mail@ashallendesign.co.uk"
     }
   ],
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "ashallendesign/short-url",
+  "name": "c-delouvencourt/short-url",
   "description": "A Laravel package for creating shortened URLs for your web apps.",
   "type": "library",
-  "homepage": "https://github.com/ash-jc-allen/short-url",
+  "homepage": "https://github.com/c-delouvencourt/short-url",
   "license": "MIT",
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-  "name": "ashallendesign/short-url",
+  "name": "c-delouvencourt/short-url",
   "description": "A Laravel package for creating shortened URLs for your web apps.",
   "type": "library",
-  "homepage": "https://github.com/ash-jc-allen/short-url",
+  "homepage": "https://github.com/c-delouvencourt/short-url",
   "license": "MIT",
   "authors": [
     {
-      "name": "Ash Allen",
-      "email": "mail@ashallendesign.co.uk"
+      "name": "Clément de Louvencourt",
+      "email": "clement@meilleursbiens.com"
     }
   ],
   "keywords": [

--- a/config/short-url.php
+++ b/config/short-url.php
@@ -39,6 +39,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Models
+    |--------------------------------------------------------------------------
+    |
+    | Define the models that are used by this package. If you have
+    | overridden the models, you can specify them here.
+    |
+    */
+    'urls_model' => \AshAllenDesign\ShortURL\Models\ShortURL::class,
+    'urls_table' => 'short_urls',
+
+    'visits_model' => \AshAllenDesign\ShortURL\Models\ShortURLVisit::class,
+    'visits_table' => 'short_url_visits',
+
+    /*
+    |--------------------------------------------------------------------------
     | Eloquent Factories
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/2019_12_22_015115_create_short_urls_table.php
+++ b/database/migrations/2019_12_22_015115_create_short_urls_table.php
@@ -13,7 +13,7 @@ class CreateShortUrlsTable extends Migration
      */
     public function up()
     {
-        Schema::connection(config('short-url.connection'))->create(config('urls_table'), function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->create(config('short-url.urls_table'), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->text('destination_url');
 
@@ -38,6 +38,6 @@ class CreateShortUrlsTable extends Migration
      */
     public function down()
     {
-        Schema::connection(config('short-url.connection'))->dropIfExists(config('urls_table'));
+        Schema::connection(config('short-url.connection'))->dropIfExists(config('short-url.urls_table'));
     }
 }

--- a/database/migrations/2019_12_22_015115_create_short_urls_table.php
+++ b/database/migrations/2019_12_22_015115_create_short_urls_table.php
@@ -13,7 +13,7 @@ class CreateShortUrlsTable extends Migration
      */
     public function up()
     {
-        Schema::connection(config('short-url.connection'))->create('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->create(config('urls_table'), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->text('destination_url');
 
@@ -38,6 +38,6 @@ class CreateShortUrlsTable extends Migration
      */
     public function down()
     {
-        Schema::connection(config('short-url.connection'))->dropIfExists('short_urls');
+        Schema::connection(config('short-url.connection'))->dropIfExists(config('urls_table'));
     }
 }

--- a/database/migrations/2019_12_22_015214_create_short_url_visits_table.php
+++ b/database/migrations/2019_12_22_015214_create_short_url_visits_table.php
@@ -13,7 +13,7 @@ class CreateShortUrlVisitsTable extends Migration
      */
     public function up()
     {
-        Schema::connection(config('short-url.connection'))->create(config('visits_table'), function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->create(config('short-url.visits_table'), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('short_url_id');
             $table->string('ip_address')->nullable();
@@ -24,7 +24,7 @@ class CreateShortUrlVisitsTable extends Migration
             $table->timestamp('visited_at');
             $table->timestamps();
 
-            $table->foreign('short_url_id')->references('id')->on(config('urls_table'))->onDelete('cascade');
+            $table->foreign('short_url_id')->references('id')->on(config('short-url.urls_table'))->onDelete('cascade');
         });
     }
 
@@ -35,6 +35,6 @@ class CreateShortUrlVisitsTable extends Migration
      */
     public function down()
     {
-        Schema::connection(config('short-url.connection'))->dropIfExists(config('visits_table'));
+        Schema::connection(config('short-url.connection'))->dropIfExists(config('short-url.visits_table'));
     }
 }

--- a/database/migrations/2019_12_22_015214_create_short_url_visits_table.php
+++ b/database/migrations/2019_12_22_015214_create_short_url_visits_table.php
@@ -13,7 +13,7 @@ class CreateShortUrlVisitsTable extends Migration
      */
     public function up()
     {
-        Schema::connection(config('short-url.connection'))->create('short_url_visits', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->create(config('visits_table'), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('short_url_id');
             $table->string('ip_address')->nullable();
@@ -24,7 +24,7 @@ class CreateShortUrlVisitsTable extends Migration
             $table->timestamp('visited_at');
             $table->timestamps();
 
-            $table->foreign('short_url_id')->references('id')->on('short_urls')->onDelete('cascade');
+            $table->foreign('short_url_id')->references('id')->on(config('urls_table'))->onDelete('cascade');
         });
     }
 
@@ -35,6 +35,6 @@ class CreateShortUrlVisitsTable extends Migration
      */
     public function down()
     {
-        Schema::connection(config('short-url.connection'))->dropIfExists('short_url_visits');
+        Schema::connection(config('short-url.connection'))->dropIfExists(config('visits_table'));
     }
 }

--- a/database/migrations/2020_02_11_224848_update_short_url_table_for_version_two_zero_zero.php
+++ b/database/migrations/2020_02_11_224848_update_short_url_table_for_version_two_zero_zero.php
@@ -14,7 +14,7 @@ class UpdateShortURLTableForVersionTwoZeroZero extends Migration
      */
     public function up()
     {
-        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('urls_model'), function (Blueprint $table) {
             $table->integer('redirect_status_code')->after('track_visits')->default(301);
             $table->boolean('track_ip_address')->after('redirect_status_code')->default(false);
             $table->boolean('track_operating_system')->after('track_ip_address')->default(false);
@@ -25,7 +25,7 @@ class UpdateShortURLTableForVersionTwoZeroZero extends Migration
             $table->boolean('track_device_type')->after('track_referer_url')->default(false);
         });
 
-        DB::connection(config('short-url.connection'))->table('short_urls')->update([
+        DB::connection(config('short-url.connection'))->table(config('urls_table'))->update([
             'track_ip_address' => config('short-url.tracking.fields.ip_address'),
             'track_operating_system' => config('short-url.tracking.fields.operating_system'),
             'track_operating_system_version' => config('short-url.tracking.fields.operating_system_version'),
@@ -43,7 +43,7 @@ class UpdateShortURLTableForVersionTwoZeroZero extends Migration
      */
     public function down()
     {
-        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('urls_table'), function (Blueprint $table) {
             $table->dropColumn([
                 'redirect_status_code',
                 'track_ip_address',

--- a/database/migrations/2020_02_11_224848_update_short_url_table_for_version_two_zero_zero.php
+++ b/database/migrations/2020_02_11_224848_update_short_url_table_for_version_two_zero_zero.php
@@ -14,7 +14,7 @@ class UpdateShortURLTableForVersionTwoZeroZero extends Migration
      */
     public function up()
     {
-        Schema::connection(config('short-url.connection'))->table(config('urls_model'), function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('short-url.urls_model'), function (Blueprint $table) {
             $table->integer('redirect_status_code')->after('track_visits')->default(301);
             $table->boolean('track_ip_address')->after('redirect_status_code')->default(false);
             $table->boolean('track_operating_system')->after('track_ip_address')->default(false);
@@ -25,7 +25,7 @@ class UpdateShortURLTableForVersionTwoZeroZero extends Migration
             $table->boolean('track_device_type')->after('track_referer_url')->default(false);
         });
 
-        DB::connection(config('short-url.connection'))->table(config('urls_table'))->update([
+        DB::connection(config('short-url.connection'))->table(config('short-url.urls_table'))->update([
             'track_ip_address' => config('short-url.tracking.fields.ip_address'),
             'track_operating_system' => config('short-url.tracking.fields.operating_system'),
             'track_operating_system_version' => config('short-url.tracking.fields.operating_system_version'),
@@ -43,7 +43,7 @@ class UpdateShortURLTableForVersionTwoZeroZero extends Migration
      */
     public function down()
     {
-        Schema::connection(config('short-url.connection'))->table(config('urls_table'), function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('short-url.urls_table'), function (Blueprint $table) {
             $table->dropColumn([
                 'redirect_status_code',
                 'track_ip_address',

--- a/database/migrations/2020_02_12_008432_update_short_url_visits_table_for_version_two_zero_zero.php
+++ b/database/migrations/2020_02_12_008432_update_short_url_visits_table_for_version_two_zero_zero.php
@@ -13,7 +13,7 @@ class UpdateShortURLVisitsTableForVersionTwoZeroZero extends Migration
      */
     public function up()
     {
-        Schema::connection(config('short-url.connection'))->table('short_url_visits', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table('short-url.short_url_visits', function (Blueprint $table) {
             $table->string('referer_url')->after('browser_version')->nullable();
             $table->string('device_type')->after('referer_url')->nullable();
         });
@@ -26,7 +26,7 @@ class UpdateShortURLVisitsTableForVersionTwoZeroZero extends Migration
      */
     public function down()
     {
-        Schema::connection(config('short-url.connection'))->table('short_url_visits', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table('short-url.short_url_visits', function (Blueprint $table) {
             $table->dropColumn(['referer_url', 'device_type']);
         });
     }

--- a/database/migrations/2020_04_10_224546_update_short_url_table_for_version_three_zero_zero.php
+++ b/database/migrations/2020_04_10_224546_update_short_url_table_for_version_three_zero_zero.php
@@ -13,7 +13,7 @@ class UpdateShortURLTableForVersionThreeZeroZero extends Migration
      */
     public function up()
     {
-        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('urls_table'), function (Blueprint $table) {
             $table->timestamp('activated_at')->after('track_device_type')->nullable()->default(now());
             $table->timestamp('deactivated_at')->after('activated_at')->nullable();
         });
@@ -26,7 +26,7 @@ class UpdateShortURLTableForVersionThreeZeroZero extends Migration
      */
     public function down()
     {
-        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('urls_table'), function (Blueprint $table) {
             $table->dropColumn(['activated_at', 'deactivated_at']);
         });
     }

--- a/database/migrations/2020_04_10_224546_update_short_url_table_for_version_three_zero_zero.php
+++ b/database/migrations/2020_04_10_224546_update_short_url_table_for_version_three_zero_zero.php
@@ -13,7 +13,7 @@ class UpdateShortURLTableForVersionThreeZeroZero extends Migration
      */
     public function up()
     {
-        Schema::connection(config('short-url.connection'))->table(config('urls_table'), function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('short-url.urls_table'), function (Blueprint $table) {
             $table->timestamp('activated_at')->after('track_device_type')->nullable()->default(now());
             $table->timestamp('deactivated_at')->after('activated_at')->nullable();
         });
@@ -26,7 +26,7 @@ class UpdateShortURLTableForVersionThreeZeroZero extends Migration
      */
     public function down()
     {
-        Schema::connection(config('short-url.connection'))->table(config('urls_table'), function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('short-url.urls_table'), function (Blueprint $table) {
             $table->dropColumn(['activated_at', 'deactivated_at']);
         });
     }

--- a/database/migrations/2020_04_20_009283_update_short_url_table_add_option_to_forward_query_params.php
+++ b/database/migrations/2020_04_20_009283_update_short_url_table_add_option_to_forward_query_params.php
@@ -13,7 +13,7 @@ class UpdateShortUrlTableAddOptionToForwardQueryParams extends Migration
      */
     public function up()
     {
-        Schema::connection(config('short-url.connection'))->table(config('urls_table'), function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('short-url.urls_table'), function (Blueprint $table) {
             $table->boolean('forward_query_params')->after('single_use')->default(false);
         });
     }
@@ -25,7 +25,7 @@ class UpdateShortUrlTableAddOptionToForwardQueryParams extends Migration
      */
     public function down()
     {
-        Schema::connection(config('short-url.connection'))->table(config('urls_table'), function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('short-url.urls_table'), function (Blueprint $table) {
             $table->dropColumn(['forward_query_params']);
         });
     }

--- a/database/migrations/2020_04_20_009283_update_short_url_table_add_option_to_forward_query_params.php
+++ b/database/migrations/2020_04_20_009283_update_short_url_table_add_option_to_forward_query_params.php
@@ -13,7 +13,7 @@ class UpdateShortUrlTableAddOptionToForwardQueryParams extends Migration
      */
     public function up()
     {
-        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('urls_table'), function (Blueprint $table) {
             $table->boolean('forward_query_params')->after('single_use')->default(false);
         });
     }
@@ -25,7 +25,7 @@ class UpdateShortUrlTableAddOptionToForwardQueryParams extends Migration
      */
     public function down()
     {
-        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
+        Schema::connection(config('short-url.connection'))->table(config('urls_table'), function (Blueprint $table) {
             $table->dropColumn(['forward_query_params']);
         });
     }

--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -41,7 +41,7 @@ class ShortURL extends Model
      *
      * @var string
      */
-    protected $table = 'short_urls';
+    protected $table;
 
     /**
      * The attributes that are mass assignable.
@@ -89,6 +89,10 @@ class ShortURL extends Model
         if (config('short-url.connection')) {
             $this->setConnection(config('short-url.connection'));
         }
+
+        if(config('short-url.urls_table')) {
+            $this->table = config('short-url.urls_table');
+        }
     }
 
     /**
@@ -130,7 +134,7 @@ class ShortURL extends Model
      */
     public function visits(): HasMany
     {
-        return $this->hasMany(ShortURLVisit::class, 'short_url_id');
+        return $this->hasMany(config('visits_model'), 'short_url_id');
     }
 
     /**

--- a/src/Models/ShortURLVisit.php
+++ b/src/Models/ShortURLVisit.php
@@ -41,7 +41,7 @@ class ShortURLVisit extends Model
      *
      * @var string
      */
-    protected $table = 'short_url_visits';
+    protected $table;
 
     /**
      * The attributes that are mass assignable.
@@ -91,6 +91,10 @@ class ShortURLVisit extends Model
         if (config('short-url.connection')) {
             $this->setConnection(config('short-url.connection'));
         }
+
+        if(config('short-url.visits_table')) {
+            $this->table = config('short-url.visits_table');
+        }
     }
 
     /**
@@ -112,6 +116,6 @@ class ShortURLVisit extends Model
      */
     public function shortURL(): BelongsTo
     {
-        return $this->belongsTo(ShortURL::class, 'short_url_id');
+        return $this->belongsTo(config('urls_model'), 'short_url_id');
     }
 }


### PR DESCRIPTION
#### Custom Tables and Models

By default, the package will use the `short_urls` and `short_url_visits` tables and the `ShortURL` and `ShortURLVisit` models. However, you may want to use your own custom tables and models.

To do this, you can set the connection name using the `urls_model`, `urls_table`, `visits_model` and `visits_table`' config value in the `config/short-url.php` file like so:

```
'urls_model' => \AshAllenDesign\ShortURL\Models\ShortURL::class,
'urls_table' => 'short_urls',

'visits_model' => \AshAllenDesign\ShortURL\Models\ShortURLVisit::class,
'visits_table' => 'short_url_visits',
```

And then create your own models that extend the package's models:

```php
namespace App\Models;

use AshAllenDesign\ShortURL\Models\ShortURL as ShortURLModel;

class ShortURL extends ShortURLModel
{
    // Your custom code here.
}
```

```php
namespace App\Models;

use AshAllenDesign\ShortURL\Models\ShortURLVisit as ShortURLVisitModel;

class ShortURLVisit extends ShortURLVisitModel
{
    // Your custom code here.
}
```