### PR TITLE
Switch user agent packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**v7.10.0 (released 2024-03-19):**
+
+- Added support for nesbot/carbon 3.0. [#246](https://github.com/ash-jc-allen/short-url/pull/246)
+
 **v7.9.0 (released 2024-03-12):**
 
 - Added support for Laravel 11. [#239](https://github.com/ash-jc-allen/short-url/pull/239)

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "nesbot/carbon": "^2.0|^3.0",
     "illuminate/container": "^8.0|^9.0|^10.0|^11.0",
     "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
-    "jenssegers/agent": "^2.6",
     "hashids/hashids": "^4.0|^5.0",
     "whichbrowser/parser": "^2.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "illuminate/container": "^8.0|^9.0|^10.0|^11.0",
     "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
     "jenssegers/agent": "^2.6",
-    "hashids/hashids": "^4.0|^5.0"
+    "hashids/hashids": "^4.0|^5.0",
+    "whichbrowser/parser": "^2.1"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",

--- a/src/Classes/Resolver.php
+++ b/src/Classes/Resolver.php
@@ -2,7 +2,6 @@
 
 namespace AshAllenDesign\ShortURL\Classes;
 
-use AshAllenDesign\ShortURL\Classes\UserAgent\UserAgentManager;
 use AshAllenDesign\ShortURL\Events\ShortURLVisited;
 use AshAllenDesign\ShortURL\Exceptions\ValidationException;
 use AshAllenDesign\ShortURL\Interfaces\UserAgentDriver;

--- a/src/Classes/UserAgent/ParserPhpDriver.php
+++ b/src/Classes/UserAgent/ParserPhpDriver.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AshAllenDesign\ShortURL\Classes\UserAgent;
+
+use AshAllenDesign\ShortURL\Interfaces\UserAgentDriver;
+use WhichBrowser\Parser;
+
+class ParserPhpDriver implements UserAgentDriver
+{
+    private Parser $parser;
+
+    public function usingUserAgentString(string $userAgentString): UserAgentDriver
+    {
+        $this->parser = new Parser($userAgentString);
+
+        return $this;
+    }
+
+    public function getOperatingSystem(): ?string
+    {
+        if ($this->isRobot()) {
+            return null;
+        }
+
+        return $this->parser->os->name ?: null;
+    }
+
+    public function getOperatingSystemVersion(): ?string
+    {
+        if ($this->isRobot()) {
+            return null;
+        }
+
+        return $this->parser->os->getVersion() ?: null;
+    }
+
+    public function getBrowser(): ?string
+    {
+        return $this->parser->browser->getName() ?: null;
+    }
+
+    public function getBrowserVersion(): ?string
+    {
+        return $this->parser->browser->getVersion() ?: null;
+    }
+
+    public function getDeviceType(): ?string
+    {
+        return $this->parser->device->type ?: null;
+    }
+
+    public function isDesktop(): bool
+    {
+        return $this->getDeviceType() === 'desktop';
+    }
+
+    public function isMobile(): bool
+    {
+        return $this->getDeviceType() === 'mobile';
+    }
+
+    public function isTablet(): bool
+    {
+        return $this->getDeviceType() === 'tablet';
+    }
+
+    public function isRobot(): bool
+    {
+        return $this->getDeviceType() === 'bot';
+    }
+}

--- a/src/Classes/UserAgent/ParserPhpDriver.php
+++ b/src/Classes/UserAgent/ParserPhpDriver.php
@@ -11,7 +11,7 @@ class ParserPhpDriver implements UserAgentDriver
 {
     private Parser $parser;
 
-    public function usingUserAgentString(string $userAgentString): UserAgentDriver
+    public function usingUserAgentString(?string $userAgentString): UserAgentDriver
     {
         $this->parser = new Parser($userAgentString);
 

--- a/src/Interfaces/UserAgentDriver.php
+++ b/src/Interfaces/UserAgentDriver.php
@@ -6,7 +6,7 @@ namespace AshAllenDesign\ShortURL\Interfaces;
 
 interface UserAgentDriver
 {
-    public function usingUserAgentString(string $userAgentString): self;
+    public function usingUserAgentString(?string $userAgentString): self;
 
     public function getOperatingSystem(): ?string;
 

--- a/src/Interfaces/UserAgentDriver.php
+++ b/src/Interfaces/UserAgentDriver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AshAllenDesign\ShortURL\Interfaces;
+
+interface UserAgentDriver
+{
+    public function usingUserAgentString(string $userAgentString): self;
+
+    public function getOperatingSystem(): ?string;
+
+    public function getOperatingSystemVersion(): ?string;
+
+    public function getBrowser(): ?string;
+
+    public function getBrowserVersion(): ?string;
+
+    public function getDeviceType(): ?string;
+
+    public function isDesktop(): bool;
+
+    public function isMobile(): bool;
+
+    public function isTablet(): bool;
+
+    public function isRobot(): bool;
+}

--- a/src/Models/Factories/ShortURLVisitFactory.php
+++ b/src/Models/Factories/ShortURLVisitFactory.php
@@ -5,7 +5,6 @@ namespace AshAllenDesign\ShortURL\Models\Factories;
 use AshAllenDesign\ShortURL\Models\ShortURLVisit;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
-use Jenssegers\Agent\Agent;
 
 /**
  * @extends Factory<ShortURLVisit>
@@ -18,18 +17,26 @@ class ShortURLVisitFactory extends Factory
     {
         return [
             'ip_address' => $this->faker->ipv4(),
-            'operating_system' => $this->faker->randomElement(
-                array_keys(Agent::getPlatforms()),
-            ),
+            'operating_system' => $this->faker->randomElement([
+                'OS X',
+                'iOS',
+                'Android',
+                'null',
+            ]),
             'operating_system_version' => $this->faker->randomFloat(8, 20),
-            'browser' => $this->faker->randomElement(Agent::getBrowsers()),
-            'browser_version' => $this->faker->userAgent(),
-            'device_type' => $this->faker->randomElement(
-                array_merge(
-                    array_keys(Agent::getPhoneDevices()),
-                    array_keys(Agent::getTabletDevices()),
-                    array_keys(Agent::getDesktopDevices()),
-                )),
+            'browser' => $this->faker->randomElement([
+                'Firefox',
+                'Safari',
+                'Chrome',
+                'Googlebot',
+            ]),
+            'browser_version' => $this->faker->randomFloat(8, 20),
+            'device_type' => $this->faker->randomElement([
+                'desktop',
+                'mobile',
+                'tablet',
+                'robot',
+            ]),
             'visited_at' => Carbon::now(),
             'referer_url' => $this->faker->url(),
             'created_at' => Carbon::now(),

--- a/src/Providers/ShortURLProvider.php
+++ b/src/Providers/ShortURLProvider.php
@@ -3,8 +3,10 @@
 namespace AshAllenDesign\ShortURL\Providers;
 
 use AshAllenDesign\ShortURL\Classes\Builder;
+use AshAllenDesign\ShortURL\Classes\UserAgent\ParserPhpDriver;
 use AshAllenDesign\ShortURL\Classes\Validation;
 use AshAllenDesign\ShortURL\Exceptions\ValidationException;
+use AshAllenDesign\ShortURL\Interfaces\UserAgentDriver;
 use Illuminate\Support\ServiceProvider;
 
 class ShortURLProvider extends ServiceProvider
@@ -48,5 +50,9 @@ class ShortURLProvider extends ServiceProvider
         if (config('short-url') && config('short-url.validate_config')) {
             (new Validation())->validateConfig();
         }
+
+        // TODO Rename the interface.
+        // TODO Make the driver configurable.
+        $this->app->bind(UserAgentDriver::class, ParserPhpDriver::class);
     }
 }

--- a/tests/Unit/Classes/ResolverTest.php
+++ b/tests/Unit/Classes/ResolverTest.php
@@ -9,8 +9,6 @@ use AshAllenDesign\ShortURL\Models\ShortURLVisit;
 use AshAllenDesign\ShortURL\Tests\Unit\TestCase;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
-use Jenssegers\Agent\Agent;
-use Mockery;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ResolverTest extends TestCase
@@ -273,7 +271,43 @@ class ResolverTest extends TestCase
     /** @test */
     public function visit_is_recorded_if_url_has_tracking_enabled_and_the_user_agent_is_empty(): void
     {
+        $shortURL = ShortURL::create([
+            'destination_url' => 'https://google.com',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'url_key' => '12345',
+            'single_use' => false,
+            'track_visits' => true,
+            'track_ip_address' => true,
+            'track_operating_system' => true,
+            'track_operating_system_version' => true,
+            'track_browser' => true,
+            'track_browser_version' => true,
+            'track_referer_url' => true,
+            'track_device_type' => true,
+            'activated_at' => now()->subSecond(),
+        ]);
 
+        $request = Request::create(
+            uri: config('short-url.default_url') . '/short/12345',
+            server: [
+                'HTTP_USER_AGENT' => null,
+            ]
+        );
+
+        $resolver = new Resolver();
+        $result = $resolver->handleVisit($request, $shortURL);
+        $this->assertTrue($result);
+
+        $this->assertDatabaseHas('short_url_visits', [
+            'short_url_id' => $shortURL->id,
+            'ip_address' => $request->ip(),
+            'operating_system' => null,
+            'operating_system_version' => null,
+            'browser' => null,
+            'browser_version' => null,
+            'referer_url' => null,
+            'device_type' => null,
+        ]);
     }
 
     /** @test */
@@ -298,31 +332,25 @@ class ResolverTest extends TestCase
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url') . '/short/12345', 'GET', [], [], [], [
-            'HTTP_referer' => 'https://google.com',
-        ]);
+        $request = Request::create(
+            uri: config('short-url.default_url') . '/short/12345',
+            server: [
+                'HTTP_referer' => 'https://google.com',
+                'HTTP_USER_AGENT' => self::trackingFieldsProvider()[1][0],
+            ]
+        );
 
-        // Mock the Agent class so that we don't have
-        // to mock the User-Agent header in the
-        // request.
-        $mock = Mockery::mock(Agent::class)->makePartial();
-        $mock->shouldReceive('platform')->twice()->withNoArgs()->andReturn('Ubuntu');
-        $mock->shouldReceive('browser')->once()->withNoArgs()->andReturn('Firefox');
-        $mock->shouldReceive('version')->once()->withArgs(['Ubuntu'])->andReturn('19.10');
-        $mock->shouldReceive('isDesktop')->once()->withNoArgs()->andReturn(false);
-        $mock->shouldReceive('isMobile')->once()->withNoArgs()->andReturn(false);
-        $mock->shouldReceive('isTablet')->once()->withNoArgs()->andReturn(true);
-
-        $resolver = new Resolver($mock);
+        $resolver = new Resolver();
         $result = $resolver->handleVisit($request, $shortURL);
         $this->assertTrue($result);
 
+        // Safari 17.4 on iOS 17.4 (iPad)
         $this->assertDatabaseHas('short_url_visits', [
             'short_url_id' => $shortURL->id,
             'ip_address' => null,
-            'operating_system' => 'Ubuntu',
-            'operating_system_version' => '19.10',
-            'browser' => 'Firefox',
+            'operating_system' => 'iOS',
+            'operating_system_version' => '17.4.1',
+            'browser' => 'Safari',
             'browser_version' => null,
             'referer_url' => null,
             'device_type' => 'tablet',
@@ -375,82 +403,23 @@ class ResolverTest extends TestCase
 
         $request = Request::create(config('short-url.default_url') . '/short/12345', 'GET', [], [], [], [
             'HTTP_referer' => 'https://google.com',
+            'HTTP_USER_AGENT' => static::trackingFieldsProvider()[1][0]
         ]);
 
-        // Mock the Agent class so that we don't have
-        // to mock the User-Agent header in the
-        // request.
-        $mock = Mockery::mock(Agent::class)->makePartial();
-        $mock->shouldReceive('platform')->twice()->withNoArgs()->andReturn('Ubuntu');
-        $mock->shouldReceive('browser')->twice()->withNoArgs()->andReturn('Firefox');
-        $mock->shouldReceive('version')->once()->withArgs(['Ubuntu'])->andReturn('19.10');
-
-        $resolver = new Resolver($mock);
+        $resolver = new Resolver();
         $result = $resolver->handleVisit($request, $shortURL);
         $this->assertTrue($result);
 
+        // Safari 17.4 on iOS 17.4 (iPad)
         $this->assertDatabaseHas('short_url_visits', [
             'short_url_id' => $shortURL->id,
             'ip_address' => $request->ip(),
-            'operating_system' => 'Ubuntu',
-            'operating_system_version' => '19.10',
-            'browser' => 'Firefox',
-            'browser_version' => 0,
             'referer_url' => 'https://google.com',
         ]);
     }
 
     /** @test */
-    public function device_type_is_stored_if_it_is_enabled()
-    {
-        $shortURL = ShortURL::create([
-            'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
-            'url_key' => '12345',
-            'single_use' => false,
-            'track_visits' => true,
-            'track_ip_address' => true,
-            'track_operating_system' => true,
-            'track_operating_system_version' => true,
-            'track_browser' => true,
-            'track_browser_version' => true,
-            'track_referer_url' => true,
-            'track_device_type' => true,
-            'activated_at' => now()->subSecond(),
-        ]);
-
-        $request = Request::create(config('short-url.default_url') . '/short/12345', 'GET', [], [], [], [
-            'HTTP_referer' => 'https://google.com',
-        ]);
-
-        // Mock the Agent class so that we don't have
-        // to mock the User-Agent header in the
-        // request.
-        $mock = Mockery::mock(Agent::class)->makePartial();
-        $mock->shouldReceive('platform')->twice()->withNoArgs()->andReturn('Ubuntu');
-        $mock->shouldReceive('browser')->twice()->withNoArgs()->andReturn('Firefox');
-        $mock->shouldReceive('version')->once()->withArgs(['Ubuntu'])->andReturn('19.10');
-        $mock->shouldReceive('version')->once()->withArgs(['Firefox'])->andReturn('71.0');
-        $mock->shouldReceive('isDesktop')->once()->withNoArgs()->andReturn(true);
-
-        $resolver = new Resolver($mock);
-        $result = $resolver->handleVisit($request, $shortURL);
-        $this->assertTrue($result);
-
-        $this->assertDatabaseHas('short_url_visits', [
-            'short_url_id' => $shortURL->id,
-            'ip_address' => $request->ip(),
-            'operating_system' => 'Ubuntu',
-            'operating_system_version' => '19.10',
-            'browser' => 'Firefox',
-            'browser_version' => '71.0',
-            'referer_url' => 'https://google.com',
-            'device_type' => 'desktop',
-        ]);
-    }
-
-    /** @test */
-    public function fields_are_not_recorded_if_all_are_true_but_track_visits_is_disabled()
+    public function fields_are_not_recorded_if_all_are_true_but_track_visits_is_disabled(): void
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
@@ -470,18 +439,10 @@ class ResolverTest extends TestCase
 
         $request = Request::create(config('short-url.default_url') . '/short/12345', 'GET', [], [], [], [
             'HTTP_referer' => 'https://google.com',
+            'HTTP_USER_AGENT' => static::trackingFieldsProvider()[1][0],
         ]);
 
-        // Mock the Agent class so that we don't have
-        // to mock the User-Agent header in the
-        // request.
-        $mock = Mockery::mock(Agent::class)->makePartial();
-        $mock->shouldReceive('platform')->never();
-        $mock->shouldReceive('browser')->never();
-        $mock->shouldReceive('version')->never();
-        $mock->shouldReceive('isDesktop')->never();
-
-        $resolver = new Resolver($mock);
+        $resolver = new Resolver();
         $result = $resolver->handleVisit($request, $shortURL);
         $this->assertTrue($result);
 


### PR DESCRIPTION
This PR removes the `jenssegers/agent` package (which doesn't appear to be updated as much anymore) and switches over to the `whichbrowser/parser` package instead.

There is a breaking change here because we're no longer accepting an `Agent` argument for the `Resolver` class' constructor.