### PR TITLE
Remove "date" property

### DIFF
--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -84,6 +84,26 @@ class ShortURL extends Model
         'updated_at',
     ];
 
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'single_use' => 'boolean',
+        'forward_query_params' => 'boolean',
+        'track_visits' => 'boolean',
+        'track_ip_address' => 'boolean',
+        'track_operating_system' => 'boolean',
+        'track_operating_system_version' => 'boolean',
+        'track_browser' => 'boolean',
+        'track_browser_version' => 'boolean',
+        'track_referer_url' => 'boolean',
+        'track_device_type' => 'boolean',
+        'activated_at' => 'datetime',
+        'deactivated_at' => 'datetime',
+    ];
+
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
@@ -104,26 +124,6 @@ class ShortURL extends Model
 
         return $modelFactory::new();
     }
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array<string, string>
-     */
-    protected $casts = [
-        'single_use' => 'boolean',
-        'forward_query_params' => 'boolean',
-        'track_visits' => 'boolean',
-        'track_ip_address' => 'boolean',
-        'track_operating_system' => 'boolean',
-        'track_operating_system_version' => 'boolean',
-        'track_browser' => 'boolean',
-        'track_browser_version' => 'boolean',
-        'track_referer_url' => 'boolean',
-        'track_device_type' => 'boolean',
-        'activated_at' => 'datetime',
-        'deactivated_at' => 'datetime',
-    ];
 
     /**
      * A short URL can be visited many times.

--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -70,21 +70,6 @@ class ShortURL extends Model
     ];
 
     /**
-     * The attributes that should be mutated to dates.
-     *
-     * @deprecated This field is no longer used in Laravel 10 and above.
-     *             It will be removed in a future release.
-     *
-     * @var array
-     */
-    protected $dates = [
-        'activated_at',
-        'deactivated_at',
-        'created_at',
-        'updated_at',
-    ];
-
-    /**
      * The attributes that should be cast to native types.
      *
      * @var array<string, string>

--- a/src/Models/ShortURLVisit.php
+++ b/src/Models/ShortURLVisit.php
@@ -63,20 +63,6 @@ class ShortURLVisit extends Model
     ];
 
     /**
-     * The attributes that should be mutated to dates.
-     *
-     * @deprecated This field is no longer used in Laravel 10 and above.
-     *             It will be removed in a future release.
-     *
-     * @var array
-     */
-    protected $dates = [
-        'visited_at',
-        'created_at',
-        'updated_at',
-    ];
-
-    /**
      * The attributes that should be cast to native types.
      *
      * @var array<string, string>


### PR DESCRIPTION
This PR removes the `dates` property from the models.

This property was removed in Laravel 10: https://laravel.com/docs/10.x/upgrade#model-dates-property