### PR TITLE
Add migration to convert false tracking fields to null

### DIFF
--- a/database/migrations/2024_04_06_000001_update_short_url_visits_table_convert_false_values_to_null.php
+++ b/database/migrations/2024_04_06_000001_update_short_url_visits_table_convert_false_values_to_null.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class UpdateShortUrlVisitsTableConvertFalseValuesToNull extends Migration
+{
+    public function up(): void
+    {
+        DB::transaction(static function (): void {
+            DB::connection(config('short-url.connection'))
+                ->table('short_url_visits')
+                ->update([
+                    'ip_address' => DB::raw("CASE WHEN ip_address = '0' THEN NULL ELSE ip_address END"),
+                    'operating_system' => DB::raw("CASE WHEN operating_system = '0' THEN NULL ELSE operating_system END"),
+                    'operating_system_version' => DB::raw("CASE WHEN operating_system_version = '0' THEN NULL ELSE operating_system_version END"),
+                    'browser' => DB::raw("CASE WHEN browser = '0' THEN NULL ELSE browser END"),
+                    'browser_version' => DB::raw("CASE WHEN browser_version = '0' THEN NULL ELSE browser_version END"),
+                    'referer_url' => DB::raw("CASE WHEN referer_url = '0' THEN NULL ELSE referer_url END"),
+                    'device_type' => DB::raw("CASE WHEN device_type = '0' THEN NULL ELSE device_type END"),
+                ]);
+        });
+    }
+}


### PR DESCRIPTION
This PR piggy backs off the back off #244 to solve issue #243.

Currently, if the user agent parser can't detect data from the user agent string, the fields will be stored as `false` in the `short_url_visits` table. For example, if we can't detect the visitor's browser version, then the `browser_version` field will be saved as `false`.

As of Short URL v8 (to be released shortly), this behaviour has slightly changed. Instead, we'll use `null` rather than `false`.

This PR uses @stevebauman's proposed database migration that will update any existing rows that are using `false` to now be `null`.

I'm going to sit on this one for a day or so and try to get some other opinions. I'm worried about corrupting anyone's data! 🤯