### PR TITLE
Extra `)` in conditionals section of the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ if ($request->date('activation')) {
     $builder = $builder->activateAt($request->date('activation'));
 };
 
-$shortURLObject = $builder->make();)
+$shortURLObject = $builder->make();
 ```
 
 This could be rewritten using `when` like so:


### PR DESCRIPTION
Just a small typo in `README.md` conditionals section.