### PR TITLE
Fix error when app is set to use CarbonImmutable

### DIFF
--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -484,7 +484,7 @@ class Builder
         }
 
         if (! $this->activateAt) {
-            $this->activateAt = now();
+            $this->activateAt = Carbon::now();
         }
 
         $this->setTrackingOptions();

--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\ShortURL\Models;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -27,10 +27,10 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property bool $track_browser_version
  * @property bool $track_referer_url
  * @property bool $track_device_type
- * @property Carbon $activated_at
- * @property Carbon|null $deactivated_at
- * @property Carbon $created_at
- * @property Carbon $updated_at
+ * @property CarbonInterface $activated_at
+ * @property CarbonInterface|null $deactivated_at
+ * @property CarbonInterface $created_at
+ * @property CarbonInterface $updated_at
  */
 class ShortURL extends Model
 {

--- a/src/Models/ShortURLVisit.php
+++ b/src/Models/ShortURLVisit.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\ShortURL\Models;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -19,10 +19,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $browser
  * @property string $browser_version
  * @property string $device_type
- * @property Carbon $visited_at
+ * @property CarbonInterface $visited_at
  * @property string $referer_url
- * @property Carbon $created_at
- * @property Carbon $updated_at
+ * @property CarbonInterface $created_at
+ * @property CarbonInterface $updated_at
  */
 class ShortURLVisit extends Model
 {

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -9,8 +9,11 @@ use AshAllenDesign\ShortURL\Exceptions\ShortURLException;
 use AshAllenDesign\ShortURL\Exceptions\ValidationException;
 use AshAllenDesign\ShortURL\Models\ShortURL;
 use AshAllenDesign\ShortURL\Tests\Unit\TestCase;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Hashids\Hashids;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Date;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestWith;
 use ShortURL as ShortURLAlias;
@@ -592,5 +595,19 @@ final class BuilderTest extends TestCase
             ->make();
 
         $this->assertSame('https://short-url.com/short/abc123', $shortUrl->default_short_url);
+    }
+
+    #[Test]
+    public function builder_works_when_the_date_facade_is_set_to_use_carbon_immutable(): void
+    {
+        Date::use(CarbonImmutable::class);
+
+        $shortUrl = app(Builder::class)
+            ->destinationUrl('https://domain.com')
+            ->make();
+
+        $this->assertInstanceOf(CarbonImmutable::class, $shortUrl->activated_at);
+
+        Date::useDefault();
     }
 }

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -9,7 +9,6 @@ use AshAllenDesign\ShortURL\Exceptions\ShortURLException;
 use AshAllenDesign\ShortURL\Exceptions\ValidationException;
 use AshAllenDesign\ShortURL\Models\ShortURL;
 use AshAllenDesign\ShortURL\Tests\Unit\TestCase;
-use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Hashids\Hashids;
 use Illuminate\Support\Facades\Config;

--- a/tests/Unit/Models/ShortURL/CastsTest.php
+++ b/tests/Unit/Models/ShortURL/CastsTest.php
@@ -7,6 +7,8 @@ namespace AshAllenDesign\ShortURL\Tests\Unit\Models\ShortURL;
 use AshAllenDesign\ShortURL\Models\ShortURL;
 use AshAllenDesign\ShortURL\Tests\Unit\TestCase;
 use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Date;
 use PHPUnit\Framework\Attributes\Test;
 
 final class CastsTest extends TestCase
@@ -28,6 +30,29 @@ final class CastsTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $shortUrl->deactivated_at);
         $this->assertInstanceOf(Carbon::class, $shortUrl->created_at);
         $this->assertInstanceOf(Carbon::class, $shortUrl->updated_at);
+    }
+
+    #[Test]
+    public function carbon_immutable_date_objects_are_returned_when_the_date_facade_is_set_to_use_carbon_immutable(): void
+    {
+        Date::use(CarbonImmutable::class);
+
+        $shortUrl = ShortURL::factory()
+            ->create([
+                'activated_at' => now(),
+                'deactivated_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+        $shortUrl->refresh();
+
+        $this->assertInstanceOf(CarbonImmutable::class, $shortUrl->activated_at);
+        $this->assertInstanceOf(CarbonImmutable::class, $shortUrl->deactivated_at);
+        $this->assertInstanceOf(CarbonImmutable::class, $shortUrl->created_at);
+        $this->assertInstanceOf(CarbonImmutable::class, $shortUrl->updated_at);
+
+        Date::useDefault();
     }
 
     #[Test]

--- a/tests/Unit/Models/ShortURLVisit/CastsTest.php
+++ b/tests/Unit/Models/ShortURLVisit/CastsTest.php
@@ -8,6 +8,8 @@ use AshAllenDesign\ShortURL\Models\ShortURL;
 use AshAllenDesign\ShortURL\Models\ShortURLVisit;
 use AshAllenDesign\ShortURL\Tests\Unit\TestCase;
 use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Date;
 use PHPUnit\Framework\Attributes\Test;
 
 final class CastsTest extends TestCase
@@ -28,5 +30,27 @@ final class CastsTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $shortUrlVisit->visited_at);
         $this->assertInstanceOf(Carbon::class, $shortUrlVisit->created_at);
         $this->assertInstanceOf(Carbon::class, $shortUrlVisit->updated_at);
+    }
+
+    #[Test]
+    public function carbon_immutable_date_objects_are_returned_when_the_date_facade_is_set_to_use_carbon_immutable(): void
+    {
+        Date::use(CarbonImmutable::class);
+
+        $shortUrlVisit = ShortURLVisit::factory()
+            ->for(ShortURL::factory())
+            ->create([
+                'visited_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+        $shortUrlVisit->refresh();
+
+        $this->assertInstanceOf(CarbonImmutable::class, $shortUrlVisit->visited_at);
+        $this->assertInstanceOf(CarbonImmutable::class, $shortUrlVisit->created_at);
+        $this->assertInstanceOf(CarbonImmutable::class, $shortUrlVisit->updated_at);
+
+        Date::useDefault();
     }
 }


### PR DESCRIPTION
Replaces #284.

Recap: Currently the package breaks if your app has configured the `Date` facade to use `CarbonImmutable` instead of `Carbon` (as per [this blog post by Michael Dyrynda](https://dyrynda.com.au/blog/laravel-immutable-dates)).

To get it working is a one-line fix - changing one instance of `now()` to `Carbon::now()` in the `Builder` class.

Some comments/caveats:

- The reason no other changes are needed is because of Eloquent's casting magic. It ensures that _all_ `datetime` properties on Eloquent models contain an object of the correct class (either `Carbon` or `CarbonImmutable`, depending on how you've configured the `Date` facade), no matter what was used to set them.
- However, that also means the doc blocks for the `ShortURL` and `ShortURLVisit` models are incorrect: all references to `Carbon` there should be `Carbon|CarbonImmutable`. Would changing those doc blocks be a breaking change? Otherwise I can change those as well.
- The single test I've added isn't particularly defensive - it is my "failing test" that the one-liner fixes. I couldn't work out a good way of future-proofing similar bugs, short of doing something so that you can run the entire test suite with the environment set to use `CarbonImmutable` ... not sure that's worth doing!

Hope this is an improvement on the last effort.