### PR TITLE
Incremental key generation

### DIFF
--- a/database/migrations/2024_07_22_027693_update_short_url_table_make_url_key_nullable.php
+++ b/database/migrations/2024_07_22_027693_update_short_url_table_make_url_key_nullable.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateShortUrlTableMakeUrlKeyNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
+            $table->string('url_key')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
+            $table->string('url_key')->nullable(false)->change();
+        });
+    }
+}

--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -54,7 +54,7 @@ class KeyGenerator implements UrlKeyGenerator
 
     /**
      * Generate a key for the short URL with the respective short URL database ID.
-     * 
+     *
      * Much more database-efficient than generateKeyUsing and should therefore be preferred.
      */
     public function generateIncrementalKey(int $id): string

--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -53,6 +53,16 @@ class KeyGenerator implements UrlKeyGenerator
     }
 
     /**
+     * Generate a key for the short URL with the respective short URL database ID.
+     * 
+     * Much more database-efficient than generateKeyUsing and should therefore be preferred.
+     */
+    public function generateIncrementalKey(int $id): string
+    {
+        return $this->hashids->encode($id);
+    }
+
+    /**
      * Get the ID of the last inserted ShortURL. This is done so that we can predict
      * what the ID of the ShortURL that will be inserted will be called. From doing
      * this, we can create a unique hash without a reduced chance of a collision.

--- a/src/Interfaces/UrlKeyGenerator.php
+++ b/src/Interfaces/UrlKeyGenerator.php
@@ -9,4 +9,6 @@ interface UrlKeyGenerator
     public function generateRandom(): string;
 
     public function generateKeyUsing(int $seed = null): string;
+
+    public function generateIncrementalKey(int $id): string;
 }

--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -15,7 +15,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int $id
  * @property string $destination_url
  * @property string $default_short_url
- * @property string $url_key
+ * @property ?string $url_key
  * @property bool $single_use
  * @property bool $forward_query_params
  * @property bool $track_visits

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -640,7 +640,7 @@ final class BuilderTest extends TestCase
         // Make sure that the new incremental key generation method still works in an environment
         // where short URLs were generated using the old random generation algorithm.
 
-        $generateOldShortURL = fn($i) => app(Builder::class)
+        $generateOldShortURL = fn ($i) => app(Builder::class)
             ->destinationUrl('https://foo.com')
             ->generateKeyUsing(123 + $i)
             ->make();
@@ -658,14 +658,17 @@ final class BuilderTest extends TestCase
 
         for ($i = 0; $i < count($shortURLs); $i++) {
             for ($j = 0; $j < count($shortURLs); $j++) {
-                if ($i === $j) continue;
+                if ($i === $j) {
+                    continue;
+                }
                 $this->assertNotSame($shortURLs[$i]->url_key, $shortURLs[$j]->url_key);
             }
         }
     }
 
     #[Test]
-    public function test_incremental_key_generation_deletes_short_url_on_callback_exception() {
+    public function test_incremental_key_generation_deletes_short_url_on_callback_exception(): void
+    {
         $id = null;
         $exceptionThrown = false;
 
@@ -675,7 +678,7 @@ final class BuilderTest extends TestCase
                 ->beforeCreate(function ($shortURL) use (&$id) {
                     $this->assertNotNull($shortURL->id);
                     $this->assertNotNull($shortURL->url_key);
-                    
+
                     $id = $shortURL->id;
 
                     throw new \Exception('Test exception');
@@ -695,7 +698,8 @@ final class BuilderTest extends TestCase
     }
 
     #[Test]
-    public function test_old_random_key_generation_callback_exception() {
+    public function test_old_random_key_generation_callback_exception(): void
+    {
         $urlKey = null;
         $exceptionThrown = false;
 
@@ -705,7 +709,7 @@ final class BuilderTest extends TestCase
                 ->beforeCreate(function ($shortURL) use (&$urlKey) {
                     $this->assertNull($shortURL->id);
                     $this->assertNotNull($shortURL->url_key);
-                    
+
                     $urlKey = $shortURL->url_key;
 
                     throw new \Exception('Test exception');


### PR DESCRIPTION
Hello,

In production we came across a pretty nasty bug where we were experiencing a huge amount of collisions when trying to generate a new shortlink ID:

<img width="933" alt="image" src="https://github.com/user-attachments/assets/fb809fcf-6469-4349-9198-371d2798b3db">

As you can see, it had to make almost 1,000 database queries before it could insert a shortlink into the database.

Evidently, we're generating a lot of shortlinks in a small space of time, which is causing a ton of collisions.

Investigating further, we found that it was stuck in this loop:

https://github.com/ash-jc-allen/short-url/blob/6bcc4850d1cc62f957cf2f94941f196498d20ab8/src/Classes/KeyGenerator.php#L35-L38

The bug is that this loop isn't atomic: by the time we exit the loop or check the loop condition, another shortlink might have been inserted in place of ours before we could save our own new shortlink into the database. 

In this PR I have swapped the key generation implementation with something that "reserves" a row in the database first, before generating a URL key. This makes it atomic.

The implementation itself is a bit hacky, but the idea is to maintain backwards compatibility as much as possible: the only actionable change is that a new migration needs to be run.