### PR TITLE
Increase entropy to decrease likelihood of collisions

### DIFF
--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -21,9 +21,12 @@ class KeyGenerator implements UrlKeyGenerator
     }
 
     /**
-     * Generate a unique and random URL key using the Hashids package.
-     *
-     * @return string
+     * Generate a unique and random URL key using the Hashids package. We start by
+     * predicting the unique ID that the ShortURL will have in the database.
+     * Then we can encode the ID to create a unique hash. On the very
+     * unlikely chance that a generated key collides with another
+     * key, we increment the ID and then attempt to create a new
+     * unique key again.
      */
     public function generateRandom(): string
     {

--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -27,8 +27,11 @@ class KeyGenerator implements UrlKeyGenerator
      */
     public function generateRandom(): string
     {
+        $ID = $this->getLastInsertedID();
+
         do {
-            $key = $this->hashids->encodeHex($this->getLastInsertedID().uniqid());
+            $ID++;
+            $key = $this->hashids->encodeHex($ID.uniqid());
         } while (ShortURL::where('url_key', $key)->exists());
 
         return $key;

--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -21,20 +21,14 @@ class KeyGenerator implements UrlKeyGenerator
     }
 
     /**
-     * Generate a unique and random URL key using the Hashids package. We start by
-     * predicting the unique ID that the ShortURL will have in the database.
-     * Then we can encode the ID to create a unique hash. On the very
-     * unlikely chance that a generated key collides with another
-     * key, we increment the ID and then attempt to create a new
-     * unique key again.
+     * Generate a unique and random URL key using the Hashids package.
+     *
+     * @return string
      */
     public function generateRandom(): string
     {
-        $ID = $this->getLastInsertedID();
-
         do {
-            $ID++;
-            $key = $this->hashids->encode($ID);
+            $key = $this->hashids->encodeHex(uniqid());
         } while (ShortURL::where('url_key', $key)->exists());
 
         return $key;
@@ -50,15 +44,5 @@ class KeyGenerator implements UrlKeyGenerator
         return $seed
             ? $this->hashids->encode($seed)
             : $this->generateRandom();
-    }
-
-    /**
-     * Get the ID of the last inserted ShortURL. This is done so that we can predict
-     * what the ID of the ShortURL that will be inserted will be called. From doing
-     * this, we can create a unique hash without a reduced chance of a collision.
-     */
-    protected function getLastInsertedID(): int
-    {
-        return ShortURL::max('id') ?? 0;
     }
 }

--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -28,7 +28,7 @@ class KeyGenerator implements UrlKeyGenerator
     public function generateRandom(): string
     {
         do {
-            $key = $this->hashids->encodeHex(uniqid());
+            $key = $this->hashids->encodeHex($this->getLastInsertedID().uniqid());
         } while (ShortURL::where('url_key', $key)->exists());
 
         return $key;
@@ -44,5 +44,15 @@ class KeyGenerator implements UrlKeyGenerator
         return $seed
             ? $this->hashids->encode($seed)
             : $this->generateRandom();
+    }
+
+    /**
+     * Get the ID of the last inserted ShortURL. This is done so that we can predict
+     * what the ID of the ShortURL that will be inserted will be called. From doing
+     * this, we can create a unique hash without a reduced chance of a collision.
+     */
+    protected function getLastInsertedID(): int
+    {
+        return ShortURL::max('id') ?? 0;
     }
 }

--- a/tests/Unit/Classes/BuilderTest.php
+++ b/tests/Unit/Classes/BuilderTest.php
@@ -300,7 +300,7 @@ final class BuilderTest extends TestCase
         $shortURL = $builder->destinationUrl('https://domain.com')->make();
 
         $this->assertNotNull($shortURL->url_key);
-        $this->assertSame(5, strlen($shortURL->url_key));
+        $this->assertSame(12, strlen($shortURL->url_key));
     }
 
     #[Test]


### PR DESCRIPTION
This is related to PR https://github.com/ash-jc-allen/short-url/pull/290, but is a slimmer approach to decreasing the likelihood of collisions. This means that two or more queued jobs attempting to create Short URL's at the same time will have to execute at the same microsecond to generate the same short URL key (very unlikely).