### PR TITLE
Fix bug where the OS name cannot be determined from the user agent

### DIFF
--- a/src/Classes/UserAgent/ParserPhpDriver.php
+++ b/src/Classes/UserAgent/ParserPhpDriver.php
@@ -24,7 +24,7 @@ class ParserPhpDriver implements UserAgentDriver
             return null;
         }
 
-        return $this->parser->os->name ?: null;
+        return $this->parser->os->name ?? null;
     }
 
     public function getOperatingSystemVersion(): ?string

--- a/src/Classes/UserAgent/ParserPhpDriver.php
+++ b/src/Classes/UserAgent/ParserPhpDriver.php
@@ -24,6 +24,7 @@ class ParserPhpDriver implements UserAgentDriver
             return null;
         }
 
+        /** @phpstan-ignore-next-line  */
         return $this->parser->os->name ?? null;
     }
 

--- a/tests/Unit/Classes/ResolverTest.php
+++ b/tests/Unit/Classes/ResolverTest.php
@@ -84,6 +84,19 @@ final class ResolverTest extends TestCase
                     'device_type' => 'robot',
                 ],
             ],
+
+            // UC Browser 7
+            [
+                'Mozilla/4.0 (compatible; MSIE 6.0; ) Opera/UCWEB7.0.2.37/28/999',
+                [
+                    'operating_system' => null,
+                    'operating_system_version' => null,
+                    'browser' => 'UC Browser',
+                    'browser_version' => '7.0',
+                    'referer_url' => null,
+                    'device_type' => 'mobile',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR should fix issue: https://github.com/ash-jc-allen/short-url/issues/294

The underlying package can't determine the OS from this user agent string:

```text
Mozilla/4.0 (compatible; MSIE 6.0; ) Opera/UCWEB7.0.2.37/28/999
```

The package's code makes it appear that the field will always be set, so I never took into account it not being set. I've updated this now to handle those situations 🙂