### PR TITLE
ShortURL::max('id') alway integer

### DIFF
--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -59,6 +59,6 @@ class KeyGenerator implements UrlKeyGenerator
      */
     protected function getLastInsertedID(): int
     {
-        return ShortURL::max('id') ?? 0;
+        return intval(ShortURL::max('id') ?? 0);
     }
 }

--- a/src/Classes/KeyGenerator.php
+++ b/src/Classes/KeyGenerator.php
@@ -55,10 +55,10 @@ class KeyGenerator implements UrlKeyGenerator
     /**
      * Get the ID of the last inserted ShortURL. This is done so that we can predict
      * what the ID of the ShortURL that will be inserted will be called. From doing
-     * this, we can create a unique hash without a reduced chance of a collision.
+     * this, we can create a unique hash with a reduced chance of a collision.
      */
     protected function getLastInsertedID(): int
     {
-        return intval(ShortURL::max('id') ?? 0);
+        return (int) ShortURL::max('id');
     }
 }


### PR DESCRIPTION
In some versions MySQL ShortURL::max('id') will be a string (like "2") and we will get an error.