### PR TITLE
Fix MySQL collation bug

### DIFF
--- a/database/migrations/2019_12_22_015115_create_short_urls_table.php
+++ b/database/migrations/2019_12_22_015115_create_short_urls_table.php
@@ -17,12 +17,11 @@ class CreateShortUrlsTable extends Migration
             $table->bigIncrements('id');
             $table->text('destination_url');
 
-            $table->string('url_key')->unique()->when(
-                Schema::getConnection()->getConfig('driver') === 'mysql',
-                function (Blueprint $column) {
-                    $column->collation('utf8mb4_bin');
-                }
-            );
+            $urlKeyColumn = $table->string('url_key')->unique();
+
+            if (Schema::getConnection()->getConfig('driver') === 'mysql') {
+                $urlKeyColumn->collation('utf8mb4_bin');
+            }
 
             $table->string('default_short_url');
             $table->boolean('single_use');


### PR DESCRIPTION
This PR fixes a bug that's mentioned in #312, #313 and was introduced in #241.

From having a quick investigation, it looks like the `when` wasn't being entered when the migrations were being run on Laravel apps running Laravel 11 or older. This is a complete oversight on my behalf and something I should have spotted! 🤦‍♂️ 

It looks like this is now being flagged up because Laravel 12 treats `when` differently on column definitions. The `\Illuminate\Database\Schema\ColumnDefinition` extends the `\Illuminate\Support\Fluent` class which now uses the `\Illuminate\Support\Traits\Conditionable`, but it previously didn't (but I hadn't noticed). So it went unnoticed for a while because no error was being thrown in previous Laravel versions.

This should solve the issue. But I'm also going to put a test together to make sure this collation is working as expected with MySQL 😄