### PR TITLE
Attach auth user to ShortURLVisited event & why it is really needed

### DIFF
--- a/src/Classes/Resolver.php
+++ b/src/Classes/Resolver.php
@@ -11,6 +11,7 @@ use AshAllenDesign\ShortURL\Models\ShortURL;
 use AshAllenDesign\ShortURL\Models\ShortURLVisit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Auth;
 
 class Resolver
 {
@@ -39,7 +40,7 @@ class Resolver
 
         $visit = $this->recordVisit($request, $shortURL);
 
-        Event::dispatch(new ShortURLVisited($shortURL, $visit));
+        Event::dispatch(new ShortURLVisited($shortURL, $visit, Auth::user()));
 
         return true;
     }

--- a/src/Events/ShortURLVisited.php
+++ b/src/Events/ShortURLVisited.php
@@ -7,6 +7,7 @@ namespace AshAllenDesign\ShortURL\Events;
 use AshAllenDesign\ShortURL\Models\ShortURL;
 use AshAllenDesign\ShortURL\Models\ShortURLVisit;
 use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
@@ -24,9 +25,15 @@ class ShortURLVisited
      */
     public ShortURLVisit $shortURLVisit;
 
-    public function __construct(ShortURL $shortURL, ShortURLVisit $shortURLVisit)
+    /**
+     * The authenticated user.
+     */
+    public ?Authenticatable $user;
+
+    public function __construct(ShortURL $shortURL, ShortURLVisit $shortURLVisit, ?Authenticatable $user = null)
     {
         $this->shortURL = $shortURL;
         $this->shortURLVisit = $shortURLVisit;
+        $this->user = $user;
     }
 }


### PR DESCRIPTION
Hi @ash-jc-allen ,

Understand someone has made a somewhat similar PR previously & you closed it at

https://github.com/ash-jc-allen/short-url/pull/237/files

However I decide to give my take on it & to hopefully convince you on why it needs to be merged.

In the link above, you argued that people should write their own ShortURLVisitObserver and grab the authenticated user there and set it.

I went to tried that approach and sadly it did not work for me in laravel 12. Here is my code

```php
<?php

declare(strict_types=1);

namespace App\Observers;

use AshAllenDesign\ShortURL\Models\ShortURLVisit;
use Illuminate\Support\Facades\Auth;

class ShortUrlVisitObserver
{
    public function creating(ShortURLVisit $shortURLVisit): void
    {
        ray('creating!'); // shows up in ray

        ray(Auth::id()); // shows up as null even though I am actually logged in
        ray(request()->user()->id); // this gives Attempt to read property "id" on null error despite me being logged in
        $shortURLVisit->user_id = Auth::id();

        ray($shortURLVisit->user_id); // shows up as null too
    }
}
```

Hence the 1st reason on why I felt this PR is needed:

It appears fetching the authenticated user in an Observer class does not work in laravel 12. & Yes I have done the thing in the AppServiceProvider to link the observer with the model,

As for the 2nd reason, I would argue that it gives more consistency with Laravel. For example let's take a look at Laravel own `Registered` event

```php
<?php

namespace Illuminate\Auth\Events;

use Illuminate\Queue\SerializesModels;
use Illuminate\Contracts\Auth\Authenticatable;

class Registered
{
    use SerializesModels;

    /**
     * Create a new event instance.
     *
     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The authenticated user.
     */
    public function __construct(
        public $user,
    ) {
    }
}
```

You can see that Laravel own Registered Event pass in the authenticated user too. So passing in the authenticated user helps to make the ShortURLVisited event more laravel like.

I hope these 2 reasons combined will convince you to merge this PR. Thank you.