### PR TITLE
Add option to truncate referer url

### DIFF
--- a/config/short-url.php
+++ b/config/short-url.php
@@ -176,6 +176,7 @@ return [
     */
     'tracking' => [
         'default_enabled' => true,
+        'truncate_referer_url' => false,
 
         'fields' => [
             'ip_address' => true,

--- a/database/migrations/2025_08_06_015678_update_short_url_table_add_option_to_truncate_referer_url.php
+++ b/database/migrations/2025_08_06_015678_update_short_url_table_add_option_to_truncate_referer_url.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateShortUrlTableAddOptionToTruncateRefererUrl extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
+            $table->boolean('truncate_referer_url')->after('track_referer_url')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection(config('short-url.connection'))->table('short_urls', function (Blueprint $table) {
+            $table->dropColumn(['truncate_referer_url']);
+        });
+    }
+}

--- a/src/Classes/Builder.php
+++ b/src/Classes/Builder.php
@@ -176,7 +176,7 @@ class Builder
     {
         Route::middleware($this->middleware())->group(function (): void {
             Route::get(
-                '/' . $this->prefix() . '/{shortURLKey}',
+                '/'.$this->prefix().'/{shortURLKey}',
                 ShortURLController::class
             )->name('short-url.invoke');
         });
@@ -192,7 +192,7 @@ class Builder
         $allowedPrefixes = config('short-url.allowed_url_schemes');
 
         if (! Str::startsWith($url, config('short-url.allowed_url_schemes'))) {
-            throw new ShortURLException('The destination URL must begin with an allowed prefix: ' . implode(', ', $allowedPrefixes));
+            throw new ShortURLException('The destination URL must begin with an allowed prefix: '.implode(', ', $allowedPrefixes));
         }
 
         $this->destinationUrl = $url;
@@ -593,9 +593,9 @@ class Builder
         $baseUrl .= '/';
 
         if ($this->prefix() !== null) {
-            $baseUrl .= $this->prefix() . '/';
+            $baseUrl .= $this->prefix().'/';
         }
 
-        return $baseUrl . $this->urlKey;
+        return $baseUrl.$this->urlKey;
     }
 }

--- a/src/Classes/Resolver.php
+++ b/src/Classes/Resolver.php
@@ -117,7 +117,14 @@ class Resolver
         }
 
         if ($shortURL->track_referer_url) {
-            $visit->referer_url = $request->headers->get('referer');
+            $refererURL = $request->headers->get('referer');
+
+            // Truncate url when exceeds database limit.
+            if (strlen($refererURL) > 255 && $shortURL->truncate_referer_url) {
+                $refererURL = substr($refererURL, 0, 255);
+            }
+
+            $visit->referer_url = $refererURL;
         }
 
         if ($shortURL->track_device_type) {

--- a/src/Models/ShortURL.php
+++ b/src/Models/ShortURL.php
@@ -27,6 +27,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property bool $track_browser
  * @property bool $track_browser_version
  * @property bool $track_referer_url
+ * @property bool $truncate_referer_url
  * @property bool $track_device_type
  * @property CarbonInterface $activated_at
  * @property CarbonInterface|null $deactivated_at
@@ -66,6 +67,7 @@ class ShortURL extends Model
         'track_browser',
         'track_browser_version',
         'track_referer_url',
+        'truncate_referer_url',
         'track_device_type',
         'activated_at',
         'deactivated_at',
@@ -86,6 +88,7 @@ class ShortURL extends Model
         'track_browser' => 'boolean',
         'track_browser_version' => 'boolean',
         'track_referer_url' => 'boolean',
+        'truncate_referer_url' => 'boolean',
         'track_device_type' => 'boolean',
         'activated_at' => 'datetime',
         'deactivated_at' => 'datetime',

--- a/tests/Unit/Classes/ResolverTest.php
+++ b/tests/Unit/Classes/ResolverTest.php
@@ -118,7 +118,7 @@ final class ResolverTest extends TestCase
 
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -126,7 +126,7 @@ final class ResolverTest extends TestCase
 
         ShortURLVisit::create(['short_url_id' => $shortURL->id, 'visited_at' => now()]);
 
-        $request = Request::create(config('short-url.default_url') . '/short/12345');
+        $request = Request::create(config('short-url.default_url').'/short/12345');
 
         $resolver = app(Resolver::class);
         $resolver->handleVisit($request, $shortURL);
@@ -137,14 +137,14 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url') . '/short/12345');
+        $request = Request::create(config('short-url.default_url').'/short/12345');
 
         $resolver = app(Resolver::class);
         $result = $resolver->handleVisit($request, $shortURL);
@@ -157,7 +157,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -166,7 +166,7 @@ final class ResolverTest extends TestCase
 
         ShortURLVisit::create(['short_url_id' => $shortURL->id, 'visited_at' => now()]);
 
-        $request = Request::create(config('short-url.default_url') . '/short/12345');
+        $request = Request::create(config('short-url.default_url').'/short/12345');
 
         $resolver = app(Resolver::class);
         $result = $resolver->handleVisit($request, $shortURL);
@@ -178,14 +178,14 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => false,
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url') . '/short/12345');
+        $request = Request::create(config('short-url.default_url').'/short/12345');
 
         $resolver = new Resolver(new ParserPhpDriver(), new Validation());
         $result = $resolver->handleVisit($request, $shortURL);
@@ -208,7 +208,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -223,7 +223,7 @@ final class ResolverTest extends TestCase
         ]);
 
         $request = Request::create(
-            uri: config('short-url.default_url') . '/short/12345',
+            uri: config('short-url.default_url').'/short/12345',
             server: [
                 'HTTP_USER_AGENT' => $userAgent,
             ]
@@ -246,7 +246,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -261,7 +261,7 @@ final class ResolverTest extends TestCase
         ]);
 
         $request = Request::create(
-            uri: config('short-url.default_url') . '/short/12345',
+            uri: config('short-url.default_url').'/short/12345',
             server: [
                 'HTTP_USER_AGENT' => 'INVALID',
             ]
@@ -288,7 +288,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -303,7 +303,7 @@ final class ResolverTest extends TestCase
         ]);
 
         $request = Request::create(
-            uri: config('short-url.default_url') . '/short/12345',
+            uri: config('short-url.default_url').'/short/12345',
             server: [
                 'HTTP_USER_AGENT' => null,
             ]
@@ -333,7 +333,7 @@ final class ResolverTest extends TestCase
 
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -348,7 +348,7 @@ final class ResolverTest extends TestCase
         ]);
 
         $request = Request::create(
-            uri: config('short-url.default_url') . '/short/12345',
+            uri: config('short-url.default_url').'/short/12345',
             server: [
                 'HTTP_referer' => 'https://google.com',
                 'HTTP_USER_AGENT' => self::trackingFieldsProvider()[1][0],
@@ -377,14 +377,14 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => false,
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url') . '/short/12345');
+        $request = Request::create(config('short-url.default_url').'/short/12345');
 
         $resolver = app(Resolver::class);
 
@@ -402,7 +402,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -416,7 +416,7 @@ final class ResolverTest extends TestCase
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url') . '/short/12345', 'GET', [], [], [], [
+        $request = Request::create(config('short-url.default_url').'/short/12345', 'GET', [], [], [], [
             'HTTP_referer' => 'https://google.com',
             'HTTP_USER_AGENT' => static::trackingFieldsProvider()[1][0],
         ]);
@@ -438,7 +438,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -453,7 +453,7 @@ final class ResolverTest extends TestCase
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url') . '/short/12345', 'GET', [], [], [], [
+        $request = Request::create(config('short-url.default_url').'/short/12345', 'GET', [], [], [], [
             'HTTP_referer' => 'https://google.com/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxooooo',
             'HTTP_USER_AGENT' => static::trackingFieldsProvider()[1][0],
         ]);
@@ -475,7 +475,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => false,
@@ -489,7 +489,7 @@ final class ResolverTest extends TestCase
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url') . '/short/12345', 'GET', [], [], [], [
+        $request = Request::create(config('short-url.default_url').'/short/12345', 'GET', [], [], [], [
             'HTTP_referer' => 'https://google.com',
             'HTTP_USER_AGENT' => static::trackingFieldsProvider()[1][0],
         ]);

--- a/tests/Unit/Classes/ResolverTest.php
+++ b/tests/Unit/Classes/ResolverTest.php
@@ -118,7 +118,7 @@ final class ResolverTest extends TestCase
 
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -126,7 +126,7 @@ final class ResolverTest extends TestCase
 
         ShortURLVisit::create(['short_url_id' => $shortURL->id, 'visited_at' => now()]);
 
-        $request = Request::create(config('short-url.default_url').'/short/12345');
+        $request = Request::create(config('short-url.default_url') . '/short/12345');
 
         $resolver = app(Resolver::class);
         $resolver->handleVisit($request, $shortURL);
@@ -137,14 +137,14 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url').'/short/12345');
+        $request = Request::create(config('short-url.default_url') . '/short/12345');
 
         $resolver = app(Resolver::class);
         $result = $resolver->handleVisit($request, $shortURL);
@@ -157,7 +157,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -166,7 +166,7 @@ final class ResolverTest extends TestCase
 
         ShortURLVisit::create(['short_url_id' => $shortURL->id, 'visited_at' => now()]);
 
-        $request = Request::create(config('short-url.default_url').'/short/12345');
+        $request = Request::create(config('short-url.default_url') . '/short/12345');
 
         $resolver = app(Resolver::class);
         $result = $resolver->handleVisit($request, $shortURL);
@@ -178,14 +178,14 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => false,
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url').'/short/12345');
+        $request = Request::create(config('short-url.default_url') . '/short/12345');
 
         $resolver = new Resolver(new ParserPhpDriver(), new Validation());
         $result = $resolver->handleVisit($request, $shortURL);
@@ -208,7 +208,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -223,7 +223,7 @@ final class ResolverTest extends TestCase
         ]);
 
         $request = Request::create(
-            uri: config('short-url.default_url').'/short/12345',
+            uri: config('short-url.default_url') . '/short/12345',
             server: [
                 'HTTP_USER_AGENT' => $userAgent,
             ]
@@ -246,7 +246,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -261,7 +261,7 @@ final class ResolverTest extends TestCase
         ]);
 
         $request = Request::create(
-            uri: config('short-url.default_url').'/short/12345',
+            uri: config('short-url.default_url') . '/short/12345',
             server: [
                 'HTTP_USER_AGENT' => 'INVALID',
             ]
@@ -288,7 +288,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -303,7 +303,7 @@ final class ResolverTest extends TestCase
         ]);
 
         $request = Request::create(
-            uri: config('short-url.default_url').'/short/12345',
+            uri: config('short-url.default_url') . '/short/12345',
             server: [
                 'HTTP_USER_AGENT' => null,
             ]
@@ -333,7 +333,7 @@ final class ResolverTest extends TestCase
 
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -348,7 +348,7 @@ final class ResolverTest extends TestCase
         ]);
 
         $request = Request::create(
-            uri: config('short-url.default_url').'/short/12345',
+            uri: config('short-url.default_url') . '/short/12345',
             server: [
                 'HTTP_referer' => 'https://google.com',
                 'HTTP_USER_AGENT' => self::trackingFieldsProvider()[1][0],
@@ -377,14 +377,14 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => false,
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url').'/short/12345');
+        $request = Request::create(config('short-url.default_url') . '/short/12345');
 
         $resolver = app(Resolver::class);
 
@@ -402,7 +402,7 @@ final class ResolverTest extends TestCase
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => true,
@@ -416,7 +416,7 @@ final class ResolverTest extends TestCase
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url').'/short/12345', 'GET', [], [], [], [
+        $request = Request::create(config('short-url.default_url') . '/short/12345', 'GET', [], [], [], [
             'HTTP_referer' => 'https://google.com',
             'HTTP_USER_AGENT' => static::trackingFieldsProvider()[1][0],
         ]);
@@ -434,11 +434,48 @@ final class ResolverTest extends TestCase
     }
 
     #[Test]
+    public function referer_url_is_stored_and_truncated_if_it_is_enabled(): void
+    {
+        $shortURL = ShortURL::create([
+            'destination_url' => 'https://google.com',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'url_key' => '12345',
+            'single_use' => false,
+            'track_visits' => true,
+            'track_ip_address' => true,
+            'track_operating_system' => true,
+            'track_operating_system_version' => true,
+            'track_browser' => true,
+            'track_browser_version' => true,
+            'track_referer_url' => true,
+            'truncate_referer_url' => true,
+            'track_device_type' => true,
+            'activated_at' => now()->subSecond(),
+        ]);
+
+        $request = Request::create(config('short-url.default_url') . '/short/12345', 'GET', [], [], [], [
+            'HTTP_referer' => 'https://google.com/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxooooo',
+            'HTTP_USER_AGENT' => static::trackingFieldsProvider()[1][0],
+        ]);
+
+        $resolver = app(Resolver::class);
+        $result = $resolver->handleVisit($request, $shortURL);
+        $this->assertTrue($result);
+
+        // Safari 17.4 on iOS 17.4 (iPad)
+        $this->assertDatabaseHas('short_url_visits', [
+            'short_url_id' => $shortURL->id,
+            'ip_address' => $request->ip(),
+            'referer_url' => 'https://google.com/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+        ]);
+    }
+
+    #[Test]
     public function fields_are_not_recorded_if_all_are_true_but_track_visits_is_disabled(): void
     {
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => false,
             'track_visits' => false,
@@ -452,7 +489,7 @@ final class ResolverTest extends TestCase
             'activated_at' => now()->subSecond(),
         ]);
 
-        $request = Request::create(config('short-url.default_url').'/short/12345', 'GET', [], [], [], [
+        $request = Request::create(config('short-url.default_url') . '/short/12345', 'GET', [], [], [], [
             'HTTP_referer' => 'https://google.com',
             'HTTP_USER_AGENT' => static::trackingFieldsProvider()[1][0],
         ]);

--- a/tests/Unit/Controllers/ShortURLControllerTest.php
+++ b/tests/Unit/Controllers/ShortURLControllerTest.php
@@ -23,7 +23,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -41,7 +41,7 @@ final class ShortURLControllerTest extends TestCase
 
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'forward_query_params' => false,
@@ -82,7 +82,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -98,7 +98,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -115,7 +115,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -132,7 +132,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -149,7 +149,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com?param1=abc',
-            'default_short_url' => config('short-url.default_url') . '/short/12345',
+            'default_short_url' => config('short-url.default_url').'/short/12345',
             'url_key' => '12345',
             'forward_query_params' => false,
             'redirect_status_code' => 301,

--- a/tests/Unit/Controllers/ShortURLControllerTest.php
+++ b/tests/Unit/Controllers/ShortURLControllerTest.php
@@ -23,7 +23,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -41,7 +41,7 @@ final class ShortURLControllerTest extends TestCase
 
         $shortURL = ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'forward_query_params' => false,
@@ -53,6 +53,7 @@ final class ShortURLControllerTest extends TestCase
             'track_browser' => true,
             'track_browser_version' => true,
             'track_referer_url' => false,
+            'truncate_referer_url' => false,
             'track_device_type' => true,
             'activated_at' => now()->subMinute(),
             'deactivated_at' => null,
@@ -81,7 +82,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -97,7 +98,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -114,7 +115,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -131,7 +132,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'single_use' => true,
             'track_visits' => true,
@@ -148,7 +149,7 @@ final class ShortURLControllerTest extends TestCase
     {
         ShortURL::create([
             'destination_url' => 'https://google.com?param1=abc',
-            'default_short_url' => config('short-url.default_url').'/short/12345',
+            'default_short_url' => config('short-url.default_url') . '/short/12345',
             'url_key' => '12345',
             'forward_query_params' => false,
             'redirect_status_code' => 301,


### PR DESCRIPTION
Hi, there is an issue when referer_url is too long. I added the ability to truncate long referer URLs to avoid SQL errors and prevent table overload, which can become quite large over time.