### PR TITLE
Change referer_url column type to text

### DIFF
--- a/database/migrations/2020_02_12_008432_update_short_url_visits_table_for_version_two_zero_zero.php
+++ b/database/migrations/2020_02_12_008432_update_short_url_visits_table_for_version_two_zero_zero.php
@@ -14,7 +14,7 @@ class UpdateShortURLVisitsTableForVersionTwoZeroZero extends Migration
     public function up()
     {
         Schema::connection(config('short-url.connection'))->table('short_url_visits', function (Blueprint $table) {
-            $table->string('referer_url')->after('browser_version')->nullable();
+            $table->text('referer_url')->after('browser_version')->nullable();
             $table->string('device_type')->after('referer_url')->nullable();
         });
     }


### PR DESCRIPTION
Recently I been getting server errors on Sentry, turns out some people the referer url include things like those utm_medium, utm_source, fbclid, gclid, ttclid etc and it exceeds 255 characters.

So text would be a safer choice