### PR TITLE
Pinned GitHub Action services to specific versions

### DIFF
--- a/.github/workflows/ci-phpstan.yml
+++ b/.github/workflows/ci-phpstan.yml
@@ -33,10 +33,10 @@ jobs:
         run: sudo apt-get update --fix-missing
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none

--- a/.github/workflows/ci-tests-mysql.yml
+++ b/.github/workflows/ci-tests-mysql.yml
@@ -44,10 +44,10 @@ jobs:
         run: sudo apt-get update --fix-missing
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none

--- a/.github/workflows/ci-tests-postgres.yml
+++ b/.github/workflows/ci-tests-postgres.yml
@@ -45,10 +45,10 @@ jobs:
         run: sudo apt-get update --fix-missing
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none

--- a/.github/workflows/ci-tests-sqlite.yml
+++ b/.github/workflows/ci-tests-sqlite.yml
@@ -33,10 +33,10 @@ jobs:
         run: sudo apt-get update --fix-missing
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none

--- a/phpstan-laravel-10.neon
+++ b/phpstan-laravel-10.neon
@@ -14,5 +14,6 @@ parameters:
         - '#Method AshAllenDesign\\ShortURL\\Models\\ShortURL::visits\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany<AshAllenDesign\\ShortURL\\Models\\ShortURLVisit, \$this\(AshAllenDesign\\ShortURL\\Models\\ShortURL\)> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany<AshAllenDesign\\ShortURL\\Models\\ShortURLVisit>.#'
         - '#Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany<AshAllenDesign\\ShortURL\\Models\\ShortURLVisit, \$this\(AshAllenDesign\\ShortURL\\Models\\ShortURL\)> in PHPDoc tag @return specifies 2 template types, but class Illuminate\\Database\\Eloquent\\Relations\\HasMany supports only 1: TRelatedModel#'
         - '#PHPDoc tag @use contains generic type Illuminate\\Database\\Eloquent\\Factories\\HasFactory<AshAllenDesign\\ShortURL\\Models\\Factories\\ShortURLFactory> but trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory is not generic.#'
+        - '#Property WhichBrowser\\Model\\Primitive\\NameVersion::\$name \(string\) on left side of \?\? is not nullable.#'
 
     checkMissingIterableValueType: false

--- a/src/Classes/UserAgent/ParserPhpDriver.php
+++ b/src/Classes/UserAgent/ParserPhpDriver.php
@@ -24,7 +24,6 @@ class ParserPhpDriver implements UserAgentDriver
             return null;
         }
 
-        /** @phpstan-ignore-next-line  */
         return $this->parser->os->name ?? null;
     }
 


### PR DESCRIPTION
To improve the security of GitHub Action workflows and reduce the likelihood of supply chain attacks, I've now pinned the external services used in the workflows to specific versions rather than using broader constraints.

Reference: https://www.aikido.dev/blog/checklist-github-actions